### PR TITLE
fix: streamline installer provider setup and reuse existing installs

### DIFF
--- a/aeloon/cli/providers.py
+++ b/aeloon/cli/providers.py
@@ -1,19 +1,444 @@
-"""Provider authentication CLI commands."""
+"""Provider authentication and setup CLI commands."""
 
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from pathlib import Path
+import shutil
+import sys
+from typing import Any
 
 import typer
 
 from aeloon import __logo__
 from aeloon.cli.app import app, console
 
+_DEFAULT_BOOTSTRAP_OPENROUTER_KEY = (
+    "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"
+)
+_BOOTSTRAP_FREE_TERMS = ("qwen", "deepseek", "llama", "gemma", "mistral")
+
 provider_app = typer.Typer(help="Manage providers")
 app.add_typer(provider_app, name="provider")
 
 _LOGIN_HANDLERS: dict[str, Callable[[], None]] = {}
+
+
+def _resolve_config_path(config: str | None) -> Path:
+    """Resolve the config path and make it active for this process."""
+    from aeloon.core.config.loader import get_config_path, set_config_path
+
+    if config:
+        config_path = Path(config).expanduser().resolve()
+        set_config_path(config_path)
+        console.print(f"[dim]Using config: {config_path}[/dim]")
+        return config_path
+    return get_config_path()
+
+
+def _provider_tag_text(record: dict[str, Any]) -> str:
+    tags: list[str] = []
+    if record.get("oauth"):
+        tags.append("oauth")
+    if record.get("local"):
+        tags.append("local")
+    return f" [{', '.join(tags)}]" if tags else ""
+
+
+def _provider_menu_label(record: dict[str, Any]) -> str:
+    recommended = record.get("recommended_model") or ""
+    suffix = f" - {recommended}" if recommended else ""
+    return f"{record['label']}{_provider_tag_text(record)}{suffix}"
+
+
+def _can_use_arrow_menu() -> bool:
+    """Return True when prompt_toolkit menus can safely run."""
+    stdin = getattr(sys.stdin, "isatty", None)
+    stdout = getattr(sys.stdout, "isatty", None)
+    return bool(callable(stdin) and stdin() and callable(stdout) and stdout())
+
+
+def _menu_visible_rows(total: int) -> int:
+    """Return how many menu rows should be rendered at once."""
+    terminal_lines = shutil.get_terminal_size((100, 24)).lines
+    return max(8, min(total, terminal_lines - 8))
+
+
+def _menu_window(total: int, index: int) -> tuple[int, int]:
+    """Return the visible menu window for one selected index."""
+    visible_rows = _menu_visible_rows(total)
+    if total <= visible_rows:
+        return 0, total
+
+    half = visible_rows // 2
+    start = max(0, index - half)
+    end = start + visible_rows
+    if end > total:
+        end = total
+        start = end - visible_rows
+    return start, end
+
+
+def _menu_lines(title: str, options: list[str], index: int) -> list[str]:
+    """Build visible text lines for the arrow-key menu."""
+    start, end = _menu_window(len(options), index)
+    lines = [f"Use Up/Down, Enter to confirm, Esc to cancel [{index + 1}/{len(options)}]"]
+
+    if start > 0:
+        lines.append("  ...")
+    for idx in range(start, end):
+        prefix = "> " if idx == index else "  "
+        lines.append(f"{prefix}{options[idx]}")
+    if end < len(options):
+        lines.append("  ...")
+    return lines
+
+
+def _prompt_menu_arrow(title: str, options: list[str], *, default_index: int = 0) -> int | None:
+    """Prompt for a selection using an arrow-key menu."""
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.widgets import Box, Frame, TextArea
+
+    index = default_index if 0 <= default_index < len(options) else 0
+    result: dict[str, int | None] = {"value": None}
+    body = TextArea(focusable=False, scrollbar=False)
+
+    def _render() -> None:
+        body.text = "\n".join(_menu_lines(title, options, index))
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    def _up(_event) -> None:
+        nonlocal index
+        index = (index - 1) % len(options)
+        _render()
+
+    @kb.add("down")
+    def _down(_event) -> None:
+        nonlocal index
+        index = (index + 1) % len(options)
+        _render()
+
+    @kb.add("pageup")
+    def _page_up(_event) -> None:
+        nonlocal index
+        index = max(0, index - _menu_visible_rows(len(options)))
+        _render()
+
+    @kb.add("pagedown")
+    def _page_down(_event) -> None:
+        nonlocal index
+        index = min(len(options) - 1, index + _menu_visible_rows(len(options)))
+        _render()
+
+    @kb.add("home")
+    def _home(_event) -> None:
+        nonlocal index
+        index = 0
+        _render()
+
+    @kb.add("end")
+    def _end(_event) -> None:
+        nonlocal index
+        index = len(options) - 1
+        _render()
+
+    @kb.add("enter")
+    def _enter(event) -> None:
+        result["value"] = index
+        event.app.exit()
+
+    @kb.add("escape")
+    @kb.add("c-c")
+    def _cancel(event) -> None:
+        event.app.exit()
+
+    _render()
+    prompt_app = Application(
+        layout=Layout(Box(Frame(body, title=title), padding=1)),
+        key_bindings=kb,
+        full_screen=False,
+    )
+    prompt_app.run()
+    return result["value"]
+
+
+def _prompt_menu(title: str, options: list[str], *, default_index: int = 0) -> int:
+    """Prompt for a selection and return the chosen index."""
+    if _can_use_arrow_menu():
+        try:
+            selected = _prompt_menu_arrow(title, options, default_index=default_index)
+        except Exception:
+            selected = None
+        if selected is not None:
+            return selected
+
+    console.print(f"\n[bold]{title}[/bold]")
+    for idx, option in enumerate(options, start=1):
+        marker = "[green]*[/green] " if idx - 1 == default_index else "  "
+        console.print(f"{marker}{idx}. {option}")
+
+    while True:
+        choice = typer.prompt("Choice", default=str(default_index + 1), show_default=True).strip()
+        if choice.isdigit():
+            selected = int(choice) - 1
+            if 0 <= selected < len(options):
+                return selected
+        console.print(f"[red]Please enter a number between 1 and {len(options)}.[/red]")
+
+
+def _reuse_or_prompt_api_key(provider: str, current_key: str) -> str:
+    """Return a provider API key, optionally reusing the saved one."""
+    label = provider.replace("_", "-")
+    if current_key and typer.confirm(f"Reuse the saved API key for {label}?", default=True):
+        return current_key
+    return typer.prompt(
+        f"API key for {label}",
+        default="",
+        show_default=False,
+        hide_input=True,
+    ).strip()
+
+
+def _resolve_api_base_prompt(provider: str, current_base: str, default_base: str) -> str:
+    """Return the selected API base for one provider."""
+    existing_base = current_base.strip()
+    normalized_default = default_base.strip()
+
+    if provider in {"custom", "vllm"}:
+        fallback = existing_base or "http://127.0.0.1:8000/v1"
+        return typer.prompt("API base URL", default=fallback).strip()
+    if provider == "azure_openai":
+        fallback = existing_base or "https://your-resource.openai.azure.com"
+        return typer.prompt("Azure OpenAI endpoint", default=fallback).strip()
+    if provider == "ollama":
+        fallback = existing_base or "http://127.0.0.1:11434"
+        return typer.prompt("Ollama API base URL", default=fallback).strip()
+
+    if existing_base and normalized_default and existing_base != normalized_default:
+        if typer.confirm(f"Keep the saved API base {existing_base}?", default=True):
+            return existing_base
+        return typer.prompt("API base URL", default=normalized_default).strip()
+
+    if normalized_default:
+        if typer.confirm("Override the default API base?", default=False):
+            return typer.prompt("API base URL", default=normalized_default).strip()
+        return normalized_default
+
+    return existing_base
+
+
+def _pick_free_openrouter_model(result: dict[str, Any]) -> str:
+    """Choose a free OpenRouter bootstrap model from detection results."""
+    models = [str(model) for model in result.get("models") or []]
+    free_models = [model for model in models if ":free" in model or model.endswith("/free")]
+    for term in _BOOTSTRAP_FREE_TERMS:
+        for model in free_models:
+            if term in model.lower():
+                return model
+    if free_models:
+        return free_models[0]
+    return str(result.get("recommended") or "")
+
+
+def _prompt_model_selection(
+    provider: str,
+    *,
+    current_model: str,
+    recommended: str,
+    models: list[str],
+) -> str:
+    """Prompt for the model to save for the selected provider."""
+    if models:
+        options = list(models)
+        options.append("Enter a custom model name")
+        default_index = 0
+        if current_model in models:
+            default_index = models.index(current_model)
+        elif recommended in models:
+            default_index = models.index(recommended)
+        selected = _prompt_menu(
+            f"Select model for {provider.replace('_', '-')}", options, default_index=default_index
+        )
+        if selected < len(models):
+            return models[selected]
+
+    fallback = current_model or recommended
+    return typer.prompt("Model", default=fallback).strip()
+
+
+def _apply_provider_config(
+    config: Any,
+    *,
+    provider: str,
+    model: str,
+    api_key: str = "",
+    api_base: str = "",
+) -> None:
+    """Apply one provider selection to the config model."""
+    provider_cfg = getattr(config.providers, provider)
+    config.agents.defaults.provider = provider
+    config.agents.defaults.model = model
+
+    if provider not in {"openai_codex", "github_copilot", "ollama"}:
+        provider_cfg.api_key = api_key
+    elif provider == "ollama":
+        provider_cfg.api_key = ""
+
+    if api_base:
+        provider_cfg.api_base = api_base
+    elif provider == "ollama":
+        provider_cfg.api_base = "http://127.0.0.1:11434"
+
+
+async def _detect_provider_models(
+    provider: str,
+    *,
+    api_key: str = "",
+    api_base: str = "",
+) -> dict[str, Any]:
+    """Wrap shared model detection for CLI provider setup."""
+    from aeloon.install_support import detect_models
+
+    return await detect_models(provider, api_key=api_key or None, api_base=api_base or None)
+
+
+def _current_provider_name(config: Any) -> str:
+    """Return the currently configured provider name."""
+    return str(config.agents.defaults.provider or config.get_provider_name() or "").strip()
+
+
+@provider_app.command("setup")
+def provider_setup(
+    config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
+    bootstrap_default: bool = typer.Option(
+        False,
+        "--bootstrap-default",
+        help="Use the bundled OpenRouter free-model setup without prompts",
+    ),
+) -> None:
+    """Configure the default provider and model."""
+    from aeloon.core.config.loader import load_config, save_config
+    from aeloon.install_support import provider_records, recommended_model, resolve_api_base
+
+    config_path = _resolve_config_path(config)
+    loaded = load_config(config_path)
+
+    if bootstrap_default:
+        resolved_base = resolve_api_base("openrouter")
+        detected = asyncio.run(
+            _detect_provider_models(
+                "openrouter",
+                api_key=_DEFAULT_BOOTSTRAP_OPENROUTER_KEY,
+                api_base=resolved_base,
+            )
+        )
+        selected_model = _pick_free_openrouter_model(detected)
+        if not selected_model:
+            console.print("[red]No fully free OpenRouter models were detected for bootstrap.[/red]")
+            raise typer.Exit(1)
+        _apply_provider_config(
+            loaded,
+            provider="openrouter",
+            model=selected_model,
+            api_key=_DEFAULT_BOOTSTRAP_OPENROUTER_KEY,
+            api_base=str(detected.get("resolved_api_base") or resolved_base),
+        )
+        save_config(loaded, config_path)
+        console.print(f"[green]✓[/green] Default provider set to openrouter ({selected_model})")
+        return
+
+    records = provider_records()
+    current_provider = _current_provider_name(loaded)
+    default_index = 0
+    labels: list[str] = []
+    for idx, record in enumerate(records):
+        label = _provider_menu_label(record)
+        if record["name"] == current_provider:
+            label += " [dim](current)[/dim]"
+            default_index = idx
+        labels.append(label)
+
+    provider_idx = _prompt_menu("Select provider", labels, default_index=default_index)
+    selected_record = records[provider_idx]
+    selected_provider = str(selected_record["name"])
+    current_model = loaded.agents.defaults.model if current_provider == selected_provider else ""
+    current_provider_cfg = getattr(loaded.providers, selected_provider)
+    current_key = str(current_provider_cfg.api_key or "")
+    current_base = str(current_provider_cfg.api_base or "")
+    default_base = str(resolve_api_base(selected_provider, current_base or None) or "")
+    recommended = str(
+        selected_record.get("recommended_model") or recommended_model(selected_provider)
+    )
+    api_key = ""
+    api_base = ""
+    detected: dict[str, Any] = {
+        "provider": selected_provider,
+        "recommended": recommended,
+        "resolved_api_base": default_base,
+        "detected": False,
+        "models": [],
+        "message": "",
+    }
+
+    if selected_record.get("oauth"):
+        console.print(
+            f"[cyan]{selected_record['label']} uses OAuth.[/cyan] "
+            f"Run [bold]aeloon provider login {selected_provider.replace('_', '-')}[/bold] after setup."
+        )
+    else:
+        if selected_provider not in {"ollama"}:
+            api_key = _reuse_or_prompt_api_key(selected_provider, current_key)
+        api_base = _resolve_api_base_prompt(selected_provider, current_base, default_base)
+        console.print("[dim]Detecting available models...[/dim]")
+        detected = asyncio.run(
+            _detect_provider_models(selected_provider, api_key=api_key, api_base=api_base)
+        )
+        api_base = str(detected.get("resolved_api_base") or api_base or default_base)
+
+        models = [str(model) for model in detected.get("models") or []]
+        if models:
+            if detected.get("cache_hit"):
+                console.print(f"[green]Loaded {len(models)} model(s) from cache.[/green]")
+            else:
+                console.print(f"[green]Detected {len(models)} model(s).[/green]")
+        message = str(detected.get("message") or "")
+        if message:
+            console.print(f"[dim]{message}[/dim]")
+
+    selected_model = _prompt_model_selection(
+        selected_provider,
+        current_model=current_model,
+        recommended=str(detected.get("recommended") or recommended),
+        models=[str(model) for model in detected.get("models") or []],
+    )
+    if not selected_model:
+        console.print("[red]Model cannot be empty.[/red]")
+        raise typer.Exit(1)
+
+    _apply_provider_config(
+        loaded,
+        provider=selected_provider,
+        model=selected_model,
+        api_key=api_key,
+        api_base=api_base,
+    )
+    save_config(loaded, config_path)
+
+    console.print(
+        f"[green]✓[/green] Default provider set to {selected_provider.replace('_', '-')} "
+        f"([cyan]{selected_model}[/cyan])"
+    )
+    if selected_record.get("oauth"):
+        console.print(
+            f"[dim]Next: aeloon provider login {selected_provider.replace('_', '-')}[/dim]"
+        )
+    elif selected_provider == "openrouter" and not api_key:
+        console.print("[yellow]Warning:[/yellow] OpenRouter API key is empty.")
 
 
 def _register_login(name: str) -> Callable[[Callable[[], None]], Callable[[], None]]:

--- a/aeloon/cli/providers.py
+++ b/aeloon/cli/providers.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from pathlib import Path
 import shutil
 import sys
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import typer

--- a/aeloon/install_support.py
+++ b/aeloon/install_support.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
+import time
+from pathlib import Path
 from typing import Any
 
 import httpx
 
 from aeloon.providers.registry import PROVIDERS, find_by_name
+
+_MODEL_CACHE_TTL_S = 60 * 60 * 6
 
 _DEFAULT_API_BASES: dict[str, str] = {
     "anthropic": "https://api.anthropic.com",
@@ -143,6 +148,40 @@ def _dedupe_keep_order(items: list[str]) -> list[str]:
         seen.add(value)
         result.append(value)
     return result
+
+
+def _model_cache_path(provider: str, api_base: str, api_key: str | None) -> Path:
+    from aeloon.core.config.loader import get_aeloon_home
+
+    raw = f"{provider}|{api_base}|{api_key or ''}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+    return get_aeloon_home() / "cache" / "provider-models" / f"{provider}-{digest}.json"
+
+
+def _load_model_cache(provider: str, api_base: str, api_key: str | None) -> dict[str, Any] | None:
+    path = _model_cache_path(provider, api_base, api_key)
+    if not path.exists():
+        return None
+    if time.time() - path.stat().st_mtime > _MODEL_CACHE_TTL_S:
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_model_cache(
+    provider: str, api_base: str, api_key: str | None, result: dict[str, Any]
+) -> None:
+    path = _model_cache_path(provider, api_base, api_key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, ensure_ascii=False)
+    except OSError:
+        return
 
 
 def _parse_model_ids(payload: Any) -> list[str]:
@@ -294,6 +333,14 @@ async def detect_models(
     resolved_base = resolve_api_base(name, api_base)
     recommended = recommended_model(name)
 
+    cached = _load_model_cache(name, resolved_base, api_key)
+    if cached is not None:
+        cached.setdefault("provider", name)
+        cached.setdefault("recommended", recommended)
+        cached.setdefault("resolved_api_base", resolved_base)
+        cached["cache_hit"] = True
+        return cached
+
     if name in {"openai_codex", "github_copilot"}:
         return {
             "provider": name,
@@ -329,14 +376,17 @@ async def detect_models(
             }
 
     models = _dedupe_keep_order(models)
-    return {
+    result = {
         "provider": name,
         "recommended": recommended,
         "resolved_api_base": resolved_base,
         "detected": bool(models),
-        "models": models[:40],
+        "models": models,
         "message": "" if models else "No models detected; using recommended default.",
     }
+    if models:
+        _save_model_cache(name, resolved_base, api_key, result)
+    return result
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/aeloon/providers/__init__.py
+++ b/aeloon/providers/__init__.py
@@ -1,9 +1,19 @@
-"""LLM provider abstraction module."""
+"""LLM provider abstraction module.
 
-from aeloon.providers.azure_openai_provider import AzureOpenAIProvider
+Keep package import lightweight so commands like `aeloon onboard` do not pull in
+heavy provider dependencies such as LiteLLM unless they are actually needed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from aeloon.providers.base import LLMProvider, LLMResponse
-from aeloon.providers.litellm_provider import LiteLLMProvider
-from aeloon.providers.openai_codex_provider import OpenAICodexProvider
+
+if TYPE_CHECKING:
+    from aeloon.providers.azure_openai_provider import AzureOpenAIProvider
+    from aeloon.providers.litellm_provider import LiteLLMProvider
+    from aeloon.providers.openai_codex_provider import OpenAICodexProvider
 
 __all__ = [
     "LLMProvider",
@@ -12,3 +22,20 @@ __all__ = [
     "OpenAICodexProvider",
     "AzureOpenAIProvider",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose heavy provider classes on demand."""
+    if name == "LiteLLMProvider":
+        from aeloon.providers.litellm_provider import LiteLLMProvider
+
+        return LiteLLMProvider
+    if name == "OpenAICodexProvider":
+        from aeloon.providers.openai_codex_provider import OpenAICodexProvider
+
+        return OpenAICodexProvider
+    if name == "AzureOpenAIProvider":
+        from aeloon.providers.azure_openai_provider import AzureOpenAIProvider
+
+        return AzureOpenAIProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ FROM_SOURCE=false
 SOURCE_DIR=""
 NO_MODIFY_PATH=false
 OFFLINE=false
+FORCE_REINSTALL=false
 
 LOCAL_WHEEL_FILE=""
 LOCAL_WHEELHOUSE_DIR=""
@@ -276,6 +277,7 @@ Usage:
 Options:
   --version <ref>       Install from a specific git ref (tag / branch / commit)
   --from-source [DIR]   Install from a local checkout, or the given directory
+  --reinstall           Reinstall or upgrade Aeloon even if it is already installed
   --offline             Require local wheel artifacts; do not use the network for packages
   --no-modify-path      Do not modify shell profile files
   -h, --help            Show this help
@@ -309,6 +311,10 @@ while [ $# -gt 0 ]; do
             ;;
         --offline)
             OFFLINE=true
+            shift
+            ;;
+        --reinstall)
+            FORCE_REINSTALL=true
             shift
             ;;
         --no-modify-path)
@@ -417,13 +423,19 @@ resolve_install_target() {
 
 create_venv() {
     local -a venv_args
+    if [ -x "$AELOON_VENV/bin/python" ]; then
+        info "Existing environment found, reusing it..."
+        info "Python environment ready: $($AELOON_VENV/bin/python --version)"
+        return
+    fi
+
     if [ -d "$AELOON_VENV" ]; then
-        info "Existing environment found, upgrading it..."
+        warn "Existing environment directory found without a usable Python executable; attempting to complete it."
     else
         info "Creating Python ${PYTHON_VERSION} environment..."
     fi
 
-    venv_args=(venv "$AELOON_VENV" --python "$PYTHON_VERSION" --quiet)
+    venv_args=(venv "$AELOON_VENV" --python "$PYTHON_VERSION" --quiet --allow-existing)
     if [ "$OFFLINE" = true ]; then
         venv_args+=(--no-python-downloads)
     fi
@@ -436,6 +448,15 @@ create_venv() {
 install_aeloon() {
     local target
     local -a install_args
+
+    if [ "$FORCE_REINSTALL" = false ] \
+        && [ -x "$AELOON_VENV/bin/aeloon" ] \
+        && "$AELOON_VENV/bin/python" -c "import aeloon" >/dev/null 2>&1; then
+        info "Existing Aeloon install found, reusing it."
+        info "Pass --reinstall to upgrade or reinstall the package."
+        return
+    fi
+
     target="$(resolve_install_target)"
     install_args=(install --python "$AELOON_VENV/bin/python" --upgrade)
 
@@ -692,66 +713,39 @@ choose_provider() {
 }
 
 collect_provider_settings() {
-    local detection_json
-    local default_base
+    info "Starting interactive provider setup..."
+    "$AELOON_VENV/bin/aeloon" provider setup --config "$CONFIG_PATH"
+    sync_selected_provider_from_config
+}
 
-    choose_provider
+sync_selected_provider_from_config() {
+    local selected_fields=()
 
-    case "$SELECTED_PROVIDER" in
-        default)
-            USED_BUNDLED_DEFAULT=true
-            SELECTED_PROVIDER="openrouter"
-            PROVIDER_API_KEY="$DEFAULT_PROVIDER_KEY"
-            SELECTED_API_BASE="$(installer_python detect-models --provider openrouter --api-key "" --api-base "" | "$AELOON_VENV/bin/python" -c 'import json,sys; data=json.load(sys.stdin); print(data.get("resolved_api_base", ""))')"
-            detection_json="$(detect_models_json "$SELECTED_PROVIDER" "$PROVIDER_API_KEY" "$SELECTED_API_BASE")"
-            SELECTED_MODEL="$(choose_model_from_detection "$detection_json" true "Model")"
-            ;;
-        openrouter)
-            PROVIDER_API_KEY="$(prompt_secret "API key for $SELECTED_PROVIDER")"
-            default_base="$(installer_python detect-models --provider "$SELECTED_PROVIDER" --api-key "" --api-base "" | "$AELOON_VENV/bin/python" -c 'import json,sys; data=json.load(sys.stdin); print(data.get("resolved_api_base", ""))')"
-            if [ -n "$default_base" ]; then
-                SELECTED_API_BASE="$(prompt_optional_api_base "$default_base")"
-            fi
-            ;;
-        anthropic|openai|deepseek|gemini|zhipu|dashscope|moonshot|minimax|groq|aihubmix|siliconflow|volcengine|volcengine_coding_plan|byteplus|byteplus_coding_plan)
-            PROVIDER_API_KEY="$(prompt_secret "API key for $SELECTED_PROVIDER")"
-            default_base="$(installer_python detect-models --provider "$SELECTED_PROVIDER" --api-key "" --api-base "" | "$AELOON_VENV/bin/python" -c 'import json,sys; data=json.load(sys.stdin); print(data.get("resolved_api_base", ""))')"
-            if [ -n "$default_base" ]; then
-                SELECTED_API_BASE="$(prompt_optional_api_base "$default_base")"
-            fi
-            ;;
-        custom|vllm)
-            default_base="$(prompt_line "API base URL" "http://127.0.0.1:8000/v1")"
-            SELECTED_API_BASE="$default_base"
-            PROVIDER_API_KEY="$(prompt_secret "API key (leave blank if not needed)")"
-            ;;
-        azure_openai)
-            default_base="$(prompt_line "Azure OpenAI endpoint" "https://your-resource.openai.azure.com")"
-            SELECTED_API_BASE="$default_base"
-            PROVIDER_API_KEY="$(prompt_secret "Azure OpenAI API key")"
-            ;;
-        ollama)
-            SELECTED_API_BASE="$(prompt_line "Ollama API base URL" "http://127.0.0.1:11434")"
-            ;;
-        openai_codex)
-            warn "OpenAI Codex uses OAuth. Run 'aeloon provider login openai-codex' after install."
-            ;;
-        github_copilot)
-            warn "GitHub Copilot uses OAuth. Run 'aeloon provider login github-copilot' after install."
-            ;;
-    esac
+    while IFS= read -r line; do
+        selected_fields+=("$line")
+    done < <(CONFIG_PATH="$CONFIG_PATH" "$AELOON_VENV/bin/python" - <<'PY'
+import json
+import os
+from pathlib import Path
 
-    if [ "$USED_BUNDLED_DEFAULT" = false ]; then
-        detection_json="$(detect_models_json "$SELECTED_PROVIDER" "$PROVIDER_API_KEY" "$SELECTED_API_BASE")"
-        SELECTED_MODEL="$(choose_model_from_detection "$detection_json" false "Model")"
-    fi
+config_path = Path(os.environ["CONFIG_PATH"]).expanduser()
+data = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+agents = data.get("agents", {}).get("defaults", {})
+provider = (agents.get("provider") or "").strip()
+providers = data.get("providers", {})
+provider_cfg = providers.get(provider, {}) if provider else {}
+print(provider)
+print((agents.get("model") or "").strip())
+print(provider_cfg.get("apiKey") or "")
+print(provider_cfg.get("apiBase") or "")
+PY
 
-    if [ -z "$SELECTED_MODEL" ]; then
-        die "Model cannot be empty"
-    fi
-    if [ "$SELECTED_PROVIDER" = "openrouter" ] && [ -z "$PROVIDER_API_KEY" ]; then
-        warn "OpenRouter API key is empty. Aeloon will not be able to answer until you add one."
-    fi
+)
+
+    SELECTED_PROVIDER="${selected_fields[0]:-}"
+    SELECTED_MODEL="${selected_fields[1]:-}"
+    PROVIDER_API_KEY="${selected_fields[2]:-}"
+    SELECTED_API_BASE="${selected_fields[3]:-}"
 }
 
 require_allow_from() {
@@ -912,12 +906,8 @@ run_interactive_setup() {
     if ! have_prompt_tty; then
         warn "No TTY available for prompts. Applying the default OpenRouter free-model setup."
         USED_BUNDLED_DEFAULT=true
-        SELECTED_PROVIDER="openrouter"
-        PROVIDER_API_KEY="$DEFAULT_PROVIDER_KEY"
-        SELECTED_API_BASE="$(installer_python detect-models --provider openrouter --api-key "" --api-base "" | "$AELOON_VENV/bin/python" -c 'import json,sys; data=json.load(sys.stdin); print(data.get("resolved_api_base", ""))')"
-        detection_json="$(detect_models_json "$SELECTED_PROVIDER" "$PROVIDER_API_KEY" "$SELECTED_API_BASE")"
-        SELECTED_MODEL="$(suggest_free_model_from_detection "$detection_json")"
-        [ -n "$SELECTED_MODEL" ] || die "No fully free OpenRouter models were detected for the default setup."
+        "$AELOON_VENV/bin/aeloon" provider setup --config "$CONFIG_PATH" --bootstrap-default
+        sync_selected_provider_from_config
         apply_config_updates
         INTERACTIVE_SETUP_DONE=true
         return


### PR DESCRIPTION
## Summary
- reuse existing virtual environments and installed Aeloon instances unless `--reinstall` is requested
- route installer provider/model setup through the shared Python CLI flow instead of duplicating shell-only logic
- improve provider setup UX with full model lists, scrolling menus, cached model discovery, and lighter startup imports

Closes #6