### PR TITLE
feat: add /compact slash command

### DIFF
--- a/aeloon/core/agent/commands/session.py
+++ b/aeloon/core/agent/commands/session.py
@@ -9,6 +9,9 @@ from aeloon.core.bus.events import InboundMessage, OutboundMessage
 SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(name="new", help="Start a new conversation", slash_path=("new",)),
     CommandSpec(
+        name="compact", help="Compact the current session context", slash_path=("compact",)
+    ),
+    CommandSpec(
         name="resume",
         help="Resume a saved session",
         slash_path=("resume",),
@@ -38,6 +41,42 @@ async def handle_new(env: CommandEnv, msg: InboundMessage, _args_str: str) -> Ou
         channel=msg.channel,
         chat_id=msg.chat_id,
         content="New session started.",
+    )
+
+
+async def handle_compact(env: CommandEnv, msg: InboundMessage, args_str: str) -> OutboundMessage:
+    """Archive unconsolidated history so the next turn starts from compacted context."""
+    if args_str.strip():
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="Usage: /compact",
+        )
+
+    session = env.sessions.get_or_create(msg.session_key)
+    snapshot = session.messages[session.last_consolidated :]
+    if not snapshot:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="Session is already compacted.",
+        )
+
+    archived = await env.memory_consolidator.archive_messages(snapshot)
+    if not archived:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="Failed to compact the current session.",
+        )
+
+    session.last_consolidated = len(session.messages)
+    env.sessions.save(session)
+
+    return OutboundMessage(
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=f"Compacted {len(snapshot)} messages from the current session.",
     )
 
 
@@ -104,6 +143,7 @@ async def handle_sessions(env: CommandEnv, msg: InboundMessage, args_str: str) -
 
 
 HANDLERS: BuiltinHandlerMap = {
+    "compact": handle_compact,
     "new": handle_new,
     "resume": handle_sessions,
     "sessions": handle_sessions,

--- a/tests/test_runtime_cli_improvements.py
+++ b/tests/test_runtime_cli_improvements.py
@@ -353,6 +353,55 @@ async def test_resume_command_lists_current_session(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_compact_archives_unconsolidated_session_messages(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    loop.memory_consolidator.archive_messages = AsyncMock(return_value=True)
+    session = loop.sessions.get_or_create("cli:direct")
+    session.add_message("user", "hello")
+    session.add_message("assistant", "hi")
+    loop.sessions.save(session)
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="u", chat_id="direct", content="/compact")
+    )
+
+    assert response is not None
+    assert response.content == "Compacted 2 messages from the current session."
+    loop.memory_consolidator.archive_messages.assert_awaited_once()
+    archived_messages = loop.memory_consolidator.archive_messages.await_args.args[0]
+    assert [message["content"] for message in archived_messages] == ["hello", "hi"]
+    assert loop.sessions.get_or_create("cli:direct").last_consolidated == 2
+
+
+@pytest.mark.asyncio
+async def test_compact_reports_already_compacted_session(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    session = loop.sessions.get_or_create("cli:direct")
+    session.add_message("user", "hello")
+    session.last_consolidated = len(session.messages)
+    loop.sessions.save(session)
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="u", chat_id="direct", content="/compact")
+    )
+
+    assert response is not None
+    assert response.content == "Session is already compacted."
+
+
+@pytest.mark.asyncio
+async def test_compact_rejects_arguments(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="u", chat_id="direct", content="/compact now")
+    )
+
+    assert response is not None
+    assert response.content == "Usage: /compact"
+
+
+@pytest.mark.asyncio
 async def test_sessions_switch_returns_switch_metadata(tmp_path) -> None:
     loop = _make_loop(tmp_path)
     target = loop.sessions.get_or_create("cli:other")


### PR DESCRIPTION
## Summary
- add a `/compact` slash command so users can proactively archive the current session's unconsolidated history
- keep the command in the existing session workflow with clear responses for success, no-op, and invalid usage
- add CLI tests covering compact success, already-compacted sessions, and argument validation

## Testing
- pytest tests/test_runtime_cli_improvements.py tests/test_core_integration.py tests/test_consolidate_offset.py
- ruff check aeloon/core/agent/commands/session.py tests/test_runtime_cli_improvements.py

Closes #9