### PR TITLE
fix(agent): restore plugin catalog context injection

### DIFF
--- a/aeloon/core/agent/context.py
+++ b/aeloon/core/agent/context.py
@@ -29,10 +29,15 @@ class ContextBuilder:
         self.workflows = WorkflowLoader(workspace)
         self.workflow_states = WorkflowStateStore(workspace)
         self._output_manager: OutputManager | None = None
+        self._plugin_catalog: str = ""
 
     def set_output_manager(self, manager: OutputManager) -> None:
         """Attach an OutputManager for recent-outputs injection."""
         self._output_manager = manager
+
+    def set_plugin_catalog(self, catalog: str) -> None:
+        """Attach plugin catalog text for system prompt injection."""
+        self._plugin_catalog = catalog
 
     def build_system_prompt(
         self,
@@ -57,6 +62,9 @@ class ContextBuilder:
 
         if extra_system_sections:
             parts.extend(section for section in extra_system_sections if section)
+
+        if self._plugin_catalog:
+            parts.append(self._plugin_catalog)
 
         if self._output_manager:
             recent = self._output_manager.list_recent(limit=8)

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -108,6 +108,17 @@ def test_context_builder_accepts_backend_runtime_lines(tmp_path) -> None:
     assert "HISTORY.md" not in prompt
 
 
+def test_context_builder_includes_plugin_catalog_when_set(tmp_path) -> None:
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    builder.set_plugin_catalog("# Plugins\n\n## demo\nA demo plugin")
+    prompt = builder.build_system_prompt()
+
+    assert "# Plugins" in prompt
+    assert "## demo" in prompt
+
+
 class _FakePromptLocalMemory:
     async def prepare_turn(
         self,


### PR DESCRIPTION
## Summary
- restore the minimal ContextBuilder plugin-catalog support that boot_plugins already expects
- align the plugin catalog path with Aeloon-Pro by adding the missing setter and injecting the catalog into the system prompt
- add a regression test covering plugin catalog prompt inclusion

## Verification
- pytest tests/test_context_prompt_cache.py -k plugin_catalog
- python -m aeloon agent -m \"Hello!\"
- ruff check --fix aeloon/core/agent/context.py tests/test_context_prompt_cache.py
- ruff format aeloon/core/agent/context.py tests/test_context_prompt_cache.py