### PR TITLE
Port SkillGraph plugin from Aeloon-Pro

### DIFF
--- a/aeloon/core/config/paths.py
+++ b/aeloon/core/config/paths.py
@@ -125,6 +125,40 @@ def get_cli_history_path() -> Path:
     return get_aeloon_home() / "history" / "cli_history"
 
 
+class ProjectStorageGateway:
+    """Workspace-scoped storage roots for project-local generated artifacts."""
+
+    def __init__(self, workspace: str | Path) -> None:
+        self.workspace = Path(workspace).expanduser().resolve()
+        self.root = self.workspace / ".aeloon"
+
+    def project_root(self, *, create: bool = True) -> Path:
+        return ensure_dir(self.root) if create else self.root
+
+    def project_cache_root(self, name: str | None = None, *, create: bool = True) -> Path:
+        root = self.project_root(create=create) / "cache"
+        if name:
+            root = root / name
+        return ensure_dir(root) if create else root
+
+    def project_compiled_skills_root(self, *, create: bool = True) -> Path:
+        root = self.project_cache_root(create=create) / "compiled_skills"
+        return ensure_dir(root) if create else root
+
+    def project_skills_root(self, *, create: bool = True) -> Path:
+        root = self.project_root(create=create) / "skills"
+        return ensure_dir(root) if create else root
+
+    def project_workflows_root(self, *, create: bool = True) -> Path:
+        root = self.project_root(create=create) / "workflows"
+        return ensure_dir(root) if create else root
+
+
+def get_storage_gateway(workspace: str | Path) -> ProjectStorageGateway:
+    """Return the storage gateway for a project workspace."""
+    return ProjectStorageGateway(workspace)
+
+
 def get_bridge_install_dir() -> Path:
     """Return the WhatsApp bridge directory."""
     return get_aeloon_home() / "bridge"

--- a/aeloon/plugins/SkillGraph/compiler.py
+++ b/aeloon/plugins/SkillGraph/compiler.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from aeloon.core.config.paths import get_storage_gateway
 from aeloon.providers.base import LLMProvider
 
 
@@ -54,10 +55,9 @@ def compile_skill_to_workspace(
     api = _load_skillgraph_api()
     resolved_skill_path = _resolve_skill_path(workspace, request.skill_path)
     package = api.build_skill_package(resolved_skill_path)
-    compiled_dir = workspace / "compiled_skills"
-    compiled_dir.mkdir(parents=True, exist_ok=True)
-    cache_dir = workspace / ".aeloon" / "skillgraph"
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    storage = get_storage_gateway(workspace)
+    compiled_dir = storage.project_compiled_skills_root()
+    cache_dir = storage.project_cache_root("skillgraph")
 
     output_path = compiled_dir / f"{package.slug}_workflow.py"
     report_path = cache_dir / f"{package.slug}.report.json"
@@ -122,9 +122,25 @@ class _SkillgraphApi:
 
 def _resolve_skill_path(workspace: Path, raw_path: str) -> Path:
     candidate = Path(raw_path).expanduser()
-    if not candidate.is_absolute():
-        candidate = workspace / candidate
-    return candidate.resolve()
+    if candidate.is_absolute():
+        return candidate.resolve()
+
+    workspace_candidate = workspace / candidate
+    if workspace_candidate.exists():
+        return workspace_candidate.resolve()
+
+    project_skills_root = get_storage_gateway(workspace).project_skills_root(create=False)
+    parts = candidate.parts
+    if parts and parts[0] == "skills":
+        project_skill_candidate = project_skills_root.joinpath(*parts[1:])
+        if project_skill_candidate.exists():
+            return project_skill_candidate.resolve()
+
+    direct_project_skill_candidate = project_skills_root / candidate
+    if direct_project_skill_candidate.exists():
+        return direct_project_skill_candidate.resolve()
+
+    return workspace_candidate.resolve()
 
 
 def _discover_workflow_name(output_path: Path) -> str:

--- a/aeloon/plugins/SkillGraph/skillgraph/__init__.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/__init__.py
@@ -68,6 +68,12 @@ def compile(
     cache_dir: str | Path | None = None,
     strict_validate: bool = False,
     report_path: str | Path | None = None,
+    task_context_path: str | Path | None = None,
+    verifier_command: str | None = None,
+    trace_path: str | Path | None = None,
+    target_outputs: list[str] | None = None,
+    compile_goal: str | None = None,
+    artifact_policy: str | None = None,
 ) -> Path:
     """
     Compile a SKILL.md (or skill directory) into a standalone LangGraph Python file.
@@ -89,6 +95,12 @@ def compile(
         strict_validate: If true, fail compile on SkillGraph validation errors.
             If false (default), only warn and continue code generation.
         report_path: Optional explicit path for compile report JSON.
+        task_context_path: Optional task instructions/tests path for task-aware compilation.
+        verifier_command: Optional command that verifies generated outputs.
+        trace_path: Optional successful trace to solidify into an adapter.
+        target_outputs: Optional output files the compiled artifact should produce.
+        compile_goal: Optional goal hint: guidance, adapter, workflow, or solver.
+        artifact_policy: Optional evidence policy: generic, trace, or family.
 
     Returns:
         Path to the generated .py file

--- a/aeloon/plugins/SkillGraph/skillgraph/boundary.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/boundary.py
@@ -1,0 +1,221 @@
+"""Boundary metadata builders for SkillGraph artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class PlanletSpec:
+    id: str
+    intent: str
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    bindings: dict[str, Any] = field(default_factory=dict)
+    keywords: list[str] = field(default_factory=list)
+    applicability: dict[str, Any] = field(default_factory=dict)
+    stop_policy: dict[str, Any] = field(default_factory=dict)
+
+    def model_dump(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ArtifactBoundarySpec:
+    skill_name: str
+    description: str
+    boundary: str
+    operators: list[dict[str, Any]] = field(default_factory=list)
+    planlets: list[PlanletSpec] = field(default_factory=list)
+    scope: dict[str, Any] = field(default_factory=dict)
+    selection_policy: dict[str, Any] = field(default_factory=dict)
+    execution_policy: dict[str, Any] = field(default_factory=dict)
+    risk_flags: list[str] = field(default_factory=list)
+    tool_schema: dict[str, Any] = field(default_factory=dict)
+
+    def model_dump(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["planlets"] = [
+            planlet.model_dump() if hasattr(planlet, "model_dump") else dict(planlet)
+            for planlet in self.planlets
+        ]
+        return data
+
+
+def build_boundary_spec(
+    *,
+    strategy: str,
+    skill_name: str,
+    description: str,
+    runtime_manifest: Any,
+    package: Any,
+    metadata: dict[str, Any] | None = None,
+    dispatcher_capabilities: list[Any] | None = None,
+    reference_sections: list[Any] | None = None,
+) -> ArtifactBoundarySpec:
+    del runtime_manifest, reference_sections
+    metadata = metadata or {}
+    operators = [
+        cap.to_dict() if hasattr(cap, "to_dict") else dict(cap)
+        for cap in dispatcher_capabilities or []
+    ]
+    package_slug = str(getattr(package, "slug", skill_name) or skill_name)
+    generic_office = package_slug in {"docx", "pptx"} and strategy == "dispatcher"
+    boundary = "typed_operator" if generic_office else "adapter"
+    planlets = _office_planlets(package_slug) if generic_office else []
+    selection_policy = {
+        "direct_call_level": "operator_first" if generic_office else "inspect_first",
+        "doc_read_policy": "optional" if generic_office else "required",
+    }
+    scope = {
+        "kind": "skill_package_generic" if generic_office else "skill_package",
+        "dynamic_sources_used_for_codegen": False,
+    }
+    classification = metadata.get("compilability") if isinstance(metadata, dict) else {}
+    risk_flags: list[str] = []
+    if isinstance(classification, dict) and classification.get("risk_flags"):
+        risk_flags = [str(flag) for flag in classification.get("risk_flags") or []]
+
+    return ArtifactBoundarySpec(
+        skill_name=skill_name,
+        description=description,
+        boundary=boundary,
+        operators=operators,
+        planlets=planlets,
+        scope=scope,
+        selection_policy=selection_policy,
+        execution_policy={"timeout_sec": 20, "allow_network_by_default": False},
+        risk_flags=risk_flags,
+        tool_schema=_tool_schema(operators, planlets),
+    )
+
+
+def normalize_boundary_metadata(value: Any) -> dict[str, Any]:
+    if isinstance(value, ArtifactBoundarySpec):
+        return value.model_dump()
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def summarize_boundary(value: Any) -> dict[str, Any]:
+    data = normalize_boundary_metadata(value)
+    return {
+        "boundary": data.get("boundary", ""),
+        "operator_count": len(data.get("operators") or []),
+        "planlet_count": len(data.get("planlets") or []),
+        "skill_name": data.get("skill_name", ""),
+    }
+
+
+def runtime_adapter_available(value: Any) -> bool:
+    data = normalize_boundary_metadata(value)
+    return bool(data.get("operators") or data.get("planlets"))
+
+
+def build_boundary_cache_fingerprint(value: Any) -> str:
+    payload = json.dumps(normalize_boundary_metadata(value), sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _office_planlets(package_slug: str) -> list[PlanletSpec]:
+    if package_slug == "docx":
+        return [
+            PlanletSpec(
+                id="docx_template_fill_and_validate",
+                intent="Fill and validate a DOCX template.",
+                steps=[
+                    {
+                        "id": "inspect_template",
+                        "operation": "inspect_docx",
+                        "optional": True,
+                        "arguments": {"path": "${input_path}"},
+                    },
+                    {
+                        "id": "fill_template",
+                        "operation": "replace_docx_text",
+                        "arguments": {
+                            "input_path": "${input_path}",
+                            "output_path": "${output_path}",
+                            "replacements": "${replacements}",
+                        },
+                    },
+                    {
+                        "id": "validate_text",
+                        "operation": "validate_docx_text",
+                        "arguments": {
+                            "path": "${output_path}",
+                            "must_contain": "${must_contain:[]}",
+                            "must_not_contain": "${must_not_contain:[]}",
+                        },
+                    },
+                ],
+                bindings={
+                    "required": ["input_path", "output_path", "replacements"],
+                    "optional": ["must_contain", "must_not_contain"],
+                    "autobind": {"input_path": ["files[0]"]},
+                },
+                keywords=["docx", "template", "fill"],
+                applicability={"file_extensions": [".docx"]},
+            )
+        ]
+    if package_slug == "pptx":
+        return [
+            PlanletSpec(
+                id="pptx_update_and_validate",
+                intent="Update a PPTX and validate the resulting deck.",
+                steps=[
+                    {
+                        "id": "update_text",
+                        "operation": "update_pptx_text_boxes",
+                        "arguments": {
+                            "input_pptx": "${input_pptx}",
+                            "output_pptx": "${output_pptx}",
+                            "edits": "${edits}",
+                        },
+                    },
+                    {
+                        "id": "validate_deck",
+                        "operation": "validate_pptx_file",
+                        "arguments": {"path": "${output_pptx}"},
+                    },
+                ],
+                bindings={"required": ["input_pptx", "output_pptx", "edits"]},
+                keywords=["pptx", "deck", "update"],
+                applicability={"file_extensions": [".pptx"]},
+            )
+        ]
+    return []
+
+
+def _tool_schema(operators: list[dict[str, Any]], planlets: list[PlanletSpec]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "operation": {
+                "type": "string",
+                "enum": [
+                    str(op.get("name") or op.get("id"))
+                    for op in operators
+                    if op.get("name") or op.get("id")
+                ],
+            },
+            "planlet": {
+                "type": "string",
+                "enum": [planlet.id for planlet in planlets],
+            },
+            "arguments": {"type": "object"},
+            "files": {"type": "array", "items": {"type": "string"}},
+            "execute": {"type": "boolean"},
+        },
+        "required": [],
+        "x-operator-schemas": [
+            {
+                "operation": str(op.get("name") or op.get("id")),
+                "inputs": list(op.get("inputs") or []),
+            }
+            for op in operators
+        ],
+    }

--- a/aeloon/plugins/SkillGraph/skillgraph/boundary_runtime.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/boundary_runtime.py
@@ -1,0 +1,2181 @@
+"""Shared runtime for boundary-first SkillGraph artifacts."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+_SOLVER_BOUNDARIES = {"workflow_solver", "jit_solver"}
+_GENERIC_EXECUTABLE_OPERATOR_KINDS = {
+    "docx_inspect",
+    "docx_replace_text",
+    "docx_marked_blocks",
+    "docx_validate_text",
+    "pptx_inventory",
+    "pptx_update_text_boxes",
+    "pptx_add_reference_slide",
+    "pptx_validate_file",
+}
+
+
+def run_boundary_artifact(
+    spec: dict[str, Any],
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    """Execute a boundary artifact and return the canonical runtime envelope."""
+
+    inputs = _inputs(state)
+    boundary = str(spec.get("boundary") or "adapter")
+    planlet = _select_planlet(spec, inputs)
+    if planlet is not None and (inputs.get("planlet") or not inputs.get("operation")):
+        missing = _missing_planlet_bindings(planlet, inputs)
+        if missing:
+            return _completed(
+                spec,
+                runtime_status="planlet_guidance",
+                contribution_type="planlet_guidance",
+                final_output=_planlet_guidance(planlet, missing),
+                selected_operator=None,
+                selected_planlet=planlet,
+                requires_agent_continuation=True,
+            )
+        return _execute_planlet(spec, planlet, inputs)
+
+    if boundary == "guidance":
+        return _guidance_result(spec, inputs)
+
+    operator = _select_operator(spec, inputs)
+    if operator is None:
+        return _blocked(
+            spec,
+            "no_match",
+            "No boundary operator matched the request.",
+            {"available_operations": _operator_names(spec)},
+        )
+
+    if _network_blocked(spec, operator, inputs):
+        return _blocked(
+            spec,
+            "network_risk",
+            "Operation requires network access and boundary policy blocks network by default.",
+            {"operator": operator.get("name") or operator.get("id")},
+        )
+
+    if _is_lossless_reference_operator(operator):
+        execution = _execute_lossless_reference(spec, operator, inputs)
+        if execution["status"] != "completed":
+            return _blocked(
+                spec,
+                execution.get("deopt_reason") or "reference_lookup_failed",
+                execution.get("error") or "Lossless reference lookup failed.",
+                execution,
+            )
+        return _completed(
+            spec,
+            runtime_status="guidance_only",
+            contribution_type="retrieval_guidance",
+            final_output=execution.get("final_output"),
+            selected_operator=operator,
+            requires_agent_continuation=True,
+            debug_trace={"execution": execution},
+        )
+
+    if boundary == "adapter" and not _truthy(inputs.get("execute")):
+        return _completed(
+            spec,
+            runtime_status="guidance_only",
+            contribution_type="retrieval_guidance",
+            final_output=_operator_guidance(operator),
+            selected_operator=operator,
+            requires_agent_continuation=True,
+        )
+
+    if operator.get("kind") == "reference_section":
+        return _completed(
+            spec,
+            runtime_status="guidance_only",
+            contribution_type="retrieval_guidance",
+            final_output=_operator_guidance(operator),
+            selected_operator=operator,
+            requires_agent_continuation=True,
+        )
+
+    validation = _validate_operator_arguments(operator, inputs)
+    if validation["errors"]:
+        return _blocked(
+            spec,
+            "invalid_arguments",
+            f"Invalid arguments for operation {operator.get('name') or operator.get('id')}.",
+            validation,
+        )
+
+    execution = _execute_operator(spec, operator, inputs)
+    if execution["status"] != "completed":
+        return _blocked(
+            spec,
+            execution.get("deopt_reason") or "execution_failed",
+            execution.get("error") or "Boundary operator execution failed.",
+            execution,
+        )
+
+    requires_continuation = boundary not in _SOLVER_BOUNDARIES
+    return _completed(
+        spec,
+        runtime_status="executed",
+        contribution_type="execution" if not requires_continuation else "typed_evidence",
+        final_output=execution.get("final_output"),
+        selected_operator=operator,
+        requires_agent_continuation=requires_continuation,
+        step_results={
+            str(operator.get("id") or operator.get("name")): {
+                "executor": execution.get("executor"),
+                "returncode": execution.get("returncode"),
+                "stdout": execution.get("stdout"),
+                "stderr": execution.get("stderr"),
+                "output": execution.get("final_output"),
+            }
+        },
+        debug_trace={"execution": execution},
+    )
+
+
+def normalize_boundary_envelope(
+    result: dict[str, Any],
+    spec: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Backfill boundary runtime fields onto thin or legacy generated results."""
+
+    if not isinstance(result, dict):
+        return _blocked(spec or {}, "invalid_result", f"Artifact returned {type(result).__name__}.")
+    boundary_spec = spec or {}
+    boundary = str(boundary_spec.get("boundary") or result.get("boundary") or "adapter")
+    enriched = dict(result)
+    enriched.setdefault("boundary", boundary)
+    enriched.setdefault("artifact_boundary", _summary(boundary_spec))
+    enriched["can_produce_final_answer"] = boundary in _SOLVER_BOUNDARIES
+    if boundary not in _SOLVER_BOUNDARIES:
+        enriched["requires_agent_continuation"] = True
+        if enriched.get("status") == "completed" and enriched.get("runtime_status") == "executed":
+            enriched.setdefault("contribution_type", "typed_evidence")
+    else:
+        enriched.setdefault("requires_agent_continuation", enriched.get("status") != "completed")
+    enriched.setdefault(
+        "runtime_status",
+        "executed" if enriched.get("status") == "completed" else "blocked",
+    )
+    enriched.setdefault("errors", [])
+    enriched.setdefault("produced_outputs", enriched.get("outputs", []))
+    return enriched
+
+
+def _execute_operator(
+    spec: dict[str, Any],
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    kind = str(operator.get("kind") or "")
+    try:
+        if kind in _GENERIC_EXECUTABLE_OPERATOR_KINDS:
+            return _execute_generic_operator(kind, operator, inputs)
+        if kind == "script_asset" and operator.get("script_path"):
+            return _execute_script(spec, operator, inputs)
+        if kind == "shell_command" and operator.get("commands"):
+            return _execute_shell(spec, operator, inputs)
+    except ValueError as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "invalid_arguments",
+            "error": str(exc),
+        }
+    except Exception as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "execution_exception",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "status": "blocked",
+        "deopt_reason": "unsupported_operator",
+        "error": f"Unsupported boundary operator kind: {kind or 'unknown'}",
+    }
+
+
+def _execute_generic_operator(
+    kind: str,
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    dispatch = {
+        "docx_inspect": _docx_inspect,
+        "docx_replace_text": _docx_replace_text,
+        "docx_marked_blocks": _docx_marked_blocks,
+        "docx_validate_text": _docx_validate_text,
+        "pptx_inventory": _pptx_inventory,
+        "pptx_update_text_boxes": _pptx_update_text_boxes,
+        "pptx_add_reference_slide": _pptx_add_reference_slide,
+        "pptx_validate_file": _pptx_validate_file,
+    }
+    output = dispatch[kind](operator, inputs)
+    return _completed_execution(output, executor=kind)
+
+
+def _is_lossless_reference_operator(operator: dict[str, Any]) -> bool:
+    return str(operator.get("kind") or "") in {
+        "skill_asset_list",
+        "skill_asset_get",
+        "skill_doc_search",
+    }
+
+
+def _execute_lossless_reference(
+    spec: dict[str, Any],
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    kind = str(operator.get("kind") or "")
+    try:
+        if kind == "skill_asset_list":
+            output = _lossless_list_assets(spec, inputs)
+        elif kind == "skill_asset_get":
+            output = _lossless_get_asset(spec, inputs)
+        elif kind == "skill_doc_search":
+            output = _lossless_search_docs(spec, inputs)
+        else:
+            return {
+                "status": "blocked",
+                "deopt_reason": "unsupported_reference_operator",
+                "error": f"Unsupported lossless reference operator: {kind}",
+            }
+    except ValueError as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "invalid_reference_request",
+            "error": str(exc),
+            "executor": kind,
+        }
+    except Exception as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "reference_exception",
+            "error": f"{type(exc).__name__}: {exc}",
+            "executor": kind,
+        }
+    return _completed_execution(output, executor=kind)
+
+
+def _lossless_list_assets(spec: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    args = _arguments(inputs)
+    asset_type = str(args.get("asset_type") or "").strip().lower()
+    assets = _lossless_assets(spec)
+    if asset_type:
+        assets = [
+            asset
+            for asset in assets
+            if str(asset.get("asset_type") or "").strip().lower() == asset_type
+        ]
+    return {
+        "assets": assets,
+        "asset_count": len(assets),
+        "lossless_reference": _lossless_summary(spec),
+    }
+
+
+def _lossless_get_asset(spec: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    args = _arguments(inputs)
+    path_value = str(args.get("path") or args.get("file") or "").strip()
+    if not path_value:
+        raise ValueError("Missing required argument: path")
+    asset = _find_lossless_asset(spec, path_value)
+    skill_root = _lossless_skill_root(inputs)
+    asset_path = _resolve_skill_asset_path(skill_root, path_value)
+    if not asset_path.exists():
+        raise ValueError(f"Skill asset not found in sandbox: {path_value}")
+    if not bool(asset.get("is_text")):
+        return {
+            "path": asset["path"],
+            "asset_type": asset.get("asset_type", ""),
+            "is_text": False,
+            "size_bytes": asset_path.stat().st_size,
+            "sha256": _sha256_file(asset_path),
+            "sandbox_path": str(asset_path),
+            "lossless_reference": _lossless_summary(spec),
+        }
+    text = asset_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    start_line = max(1, _safe_int(args.get("start_line"), default=1))
+    end_line = min(len(lines), max(start_line, _safe_int(args.get("end_line"), default=len(lines))))
+    max_chars = _safe_int(args.get("max_chars"), default=0)
+    selected = "\n".join(lines[start_line - 1 : end_line]) if lines else ""
+    truncated = False
+    if max_chars > 0 and len(selected) > max_chars:
+        selected = selected[:max_chars]
+        truncated = True
+    return {
+        "path": asset["path"],
+        "asset_type": asset.get("asset_type", ""),
+        "is_text": True,
+        "size_bytes": asset_path.stat().st_size,
+        "sha256": _sha256_file(asset_path),
+        "line_count": len(lines),
+        "start_line": start_line,
+        "end_line": end_line,
+        "content": selected,
+        "truncated": truncated,
+        "lossless_reference": _lossless_summary(spec),
+    }
+
+
+def _lossless_search_docs(spec: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    args = _arguments(inputs)
+    query = str(
+        args.get("query")
+        or inputs.get("request")
+        or inputs.get("task")
+        or inputs.get("topic")
+        or ""
+    ).strip()
+    if not query:
+        raise ValueError("Missing required argument: query")
+    max_results = max(1, _safe_int(args.get("max_results"), default=8))
+    terms = [term.lower() for term in re.findall(r"[A-Za-z0-9_./-]{2,}", query)]
+    if not terms:
+        terms = [query.lower()]
+    skill_root = _lossless_skill_root(inputs)
+    results: list[dict[str, Any]] = []
+    for asset in _lossless_assets(spec):
+        if not bool(asset.get("is_text")):
+            continue
+        path = str(asset.get("path") or "")
+        asset_path = _resolve_skill_asset_path(skill_root, path)
+        if not asset_path.exists():
+            continue
+        try:
+            lines = asset_path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for idx, line in enumerate(lines, start=1):
+            lower = line.lower()
+            score = sum(1 for term in terms if term in lower)
+            if score <= 0:
+                continue
+            results.append(
+                {
+                    "path": path,
+                    "line": idx,
+                    "score": score,
+                    "snippet": line.strip()[:500],
+                    "asset_type": asset.get("asset_type", ""),
+                }
+            )
+    results.sort(
+        key=lambda item: (
+            -int(item.get("score") or 0),
+            str(item.get("path") or ""),
+            int(item.get("line") or 0),
+        )
+    )
+    return {
+        "query": query,
+        "results": results[:max_results],
+        "result_count": len(results[:max_results]),
+        "total_matches": len(results),
+        "lossless_reference": _lossless_summary(spec),
+    }
+
+
+def _lossless_reference(spec: dict[str, Any]) -> dict[str, Any]:
+    scope = spec.get("scope") if isinstance(spec, dict) else {}
+    lossless = scope.get("lossless_reference") if isinstance(scope, dict) else {}
+    return lossless if isinstance(lossless, dict) else {}
+
+
+def _lossless_summary(spec: dict[str, Any]) -> dict[str, Any]:
+    lossless = _lossless_reference(spec)
+    return {
+        "strict_validated": bool(lossless.get("strict_validated")),
+        "package_hash": str(lossless.get("package_hash") or ""),
+        "capsule_hash": str(lossless.get("capsule_hash") or ""),
+        "asset_count": int(lossless.get("asset_count") or 0),
+        "text_asset_count": int(lossless.get("text_asset_count") or 0),
+        "binary_asset_count": int(lossless.get("binary_asset_count") or 0),
+    }
+
+
+def _lossless_assets(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    assets = _lossless_reference(spec).get("assets") or []
+    return [asset for asset in assets if isinstance(asset, dict) and asset.get("path")]
+
+
+def _find_lossless_asset(spec: dict[str, Any], path_value: str) -> dict[str, Any]:
+    normalized = _normalize_skill_asset_path(path_value)
+    for asset in _lossless_assets(spec):
+        if _normalize_skill_asset_path(str(asset.get("path") or "")) == normalized:
+            return asset
+    raise ValueError(f"Unknown skill asset: {path_value}")
+
+
+def _lossless_skill_root(inputs: dict[str, Any]) -> Path:
+    raw = str(inputs.get("sandbox_dir") or "").strip()
+    if raw:
+        skill_root = Path(raw) / "skill"
+        if skill_root.exists():
+            return skill_root
+    raise ValueError("Lossless reference requires sandbox_dir with a skill copy.")
+
+
+def _resolve_skill_asset_path(skill_root: Path, path_value: str) -> Path:
+    normalized = _normalize_skill_asset_path(path_value)
+    candidate = (skill_root / normalized).resolve()
+    root = skill_root.resolve()
+    if candidate != root and root not in candidate.parents:
+        raise ValueError(f"Skill asset path escapes sandbox: {path_value}")
+    return candidate
+
+
+def _normalize_skill_asset_path(path_value: str) -> str:
+    path = path_value.strip().replace("\\", "/").lstrip("/")
+    parts = [part for part in path.split("/") if part not in {"", "."}]
+    if any(part == ".." for part in parts):
+        raise ValueError(f"Invalid skill asset path: {path_value}")
+    return "/".join(parts)
+
+
+def _completed_execution(output: Any, *, executor: str) -> dict[str, Any]:
+    return {
+        "status": "completed",
+        "final_output": output,
+        "returncode": 0,
+        "stdout": json.dumps(output, ensure_ascii=False),
+        "stderr": "",
+        "executor": executor,
+    }
+
+
+def _docx_inspect(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from docx import Document
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    path = _required_workspace_path_alias(
+        project_dir, args, "path", "docx_path", "input_path", "file"
+    )
+    doc = Document(str(path))
+    paragraphs = [
+        {"index": idx, "text": paragraph.text}
+        for idx, paragraph in enumerate(doc.paragraphs)
+        if paragraph.text
+    ]
+    tables = list(_docx_table_text_items(doc.tables))
+    header_footer = []
+    for section_idx, section in enumerate(doc.sections):
+        for location, part in (("header", section.header), ("footer", section.footer)):
+            for paragraph_idx, paragraph in enumerate(part.paragraphs):
+                if paragraph.text:
+                    header_footer.append(
+                        {
+                            "section": section_idx,
+                            "location": location,
+                            "paragraph": paragraph_idx,
+                            "text": paragraph.text,
+                        }
+                    )
+    all_text = "\n".join(
+        [item["text"] for item in paragraphs]
+        + [item["text"] for item in tables]
+        + [item["text"] for item in header_footer]
+    )
+    placeholders = sorted(set(re.findall(r"\{\{[^{}]{1,120}\}\}|<<[^<>]{1,120}>>", all_text)))
+    return {
+        "path": str(path),
+        "paragraph_count": len(doc.paragraphs),
+        "table_count": len(doc.tables),
+        "paragraphs": paragraphs[:120],
+        "tables": tables[:120],
+        "headers_footers": header_footer[:80],
+        "placeholders": placeholders,
+    }
+
+
+def _docx_replace_text(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from docx import Document
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    input_path = _required_workspace_path(project_dir, args, "input_path")
+    output_path = _required_workspace_path(project_dir, args, "output_path")
+    replacements = _mapping_arg(args, "replacements")
+    include_headers_footers = _truthy_arg(args, "include_headers_footers", default=True)
+    include_tables = _truthy_arg(args, "include_tables", default=True)
+    doc = Document(str(input_path))
+    changed = 0
+    for paragraph in _docx_paragraphs(
+        doc,
+        include_tables=include_tables,
+        include_headers_footers=include_headers_footers,
+    ):
+        changed += _replace_paragraph_text(paragraph, replacements)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(output_path))
+    return {
+        "input_path": str(input_path),
+        "output_path": str(output_path),
+        "replacement_count": len(replacements),
+        "changed_paragraphs": changed,
+        "exists": output_path.exists(),
+    }
+
+
+def _docx_marked_blocks(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from docx import Document
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    input_path = _required_workspace_path(project_dir, args, "input_path")
+    output_path = _required_workspace_path(project_dir, args, "output_path")
+    markers = _marker_specs(args)
+    conditions = _mapping_arg(args, "conditions", required=False)
+    doc = Document(str(input_path))
+    changed = 0
+    for marker in markers:
+        name = str(marker.get("name") or marker.get("id") or marker.get("start") or "")
+        start = str(marker.get("start") or marker.get("start_marker") or "")
+        end = str(marker.get("end") or marker.get("end_marker") or "")
+        if not start or not end:
+            raise ValueError("Each marker requires start and end")
+        keep = marker.get("keep")
+        if keep is None and name:
+            keep = conditions.get(name)
+        keep_block = bool(keep)
+        in_block = False
+        for paragraph in doc.paragraphs:
+            text = paragraph.text
+            if start in text:
+                in_block = True
+                changed += 1
+                if keep_block:
+                    paragraph.text = text.replace(start, "").replace(end, "")
+                    if end in text:
+                        in_block = False
+                else:
+                    paragraph.text = ""
+                    if end in text:
+                        in_block = False
+                continue
+            if in_block:
+                changed += 1
+                paragraph.text = text.replace(end, "") if keep_block else ""
+                if end in text:
+                    in_block = False
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(output_path))
+    return {
+        "input_path": str(input_path),
+        "output_path": str(output_path),
+        "markers_processed": len(markers),
+        "changed_paragraphs": changed,
+        "exists": output_path.exists(),
+    }
+
+
+def _docx_validate_text(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from docx import Document
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    path = _required_workspace_path_alias(
+        project_dir, args, "path", "docx_path", "input_path", "file"
+    )
+    doc = Document(str(path))
+    text = "\n".join(
+        paragraph.text
+        for paragraph in _docx_paragraphs(
+            doc,
+            include_tables=True,
+            include_headers_footers=True,
+        )
+        if paragraph.text
+    )
+    must_contain = _list_arg(args, "must_contain")
+    must_not_contain = _list_arg(args, "must_not_contain")
+    missing = [item for item in must_contain if item not in text]
+    forbidden_found = [item for item in must_not_contain if item in text]
+    return {
+        "path": str(path),
+        "ok": not missing and not forbidden_found,
+        "missing": missing,
+        "forbidden_found": forbidden_found,
+        "character_count": len(text),
+    }
+
+
+def _pptx_inventory(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from pptx import Presentation
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    input_pptx = _required_workspace_path_alias(
+        project_dir, args, "input_pptx", "pptx_path", "path", "input", "file"
+    )
+    output_json = _optional_workspace_path(project_dir, args, "output_json")
+    include_positions = _truthy_arg(args, "include_positions", default=True)
+    prs = Presentation(str(input_pptx))
+    slides: list[dict[str, Any]] = []
+    for slide_idx, slide in enumerate(prs.slides, start=1):
+        shapes: list[dict[str, Any]] = []
+        for shape in slide.shapes:
+            item = {
+                "shape_id": int(shape.shape_id),
+                "name": str(shape.name),
+                "has_text": bool(getattr(shape, "has_text_frame", False)),
+                "text": shape.text if getattr(shape, "has_text_frame", False) else "",
+            }
+            if include_positions:
+                item.update(
+                    {
+                        "left": int(shape.left),
+                        "top": int(shape.top),
+                        "width": int(shape.width),
+                        "height": int(shape.height),
+                    }
+                )
+            shapes.append(item)
+        slides.append({"slide_index": slide_idx, "shape_count": len(shapes), "shapes": shapes})
+    output = {"input_pptx": str(input_pptx), "slide_count": len(slides), "slides": slides}
+    if output_json:
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8")
+        output["output_json"] = str(output_json)
+    return output
+
+
+def _pptx_update_text_boxes(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from pptx import Presentation
+    from pptx.dml.color import RGBColor
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Pt
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    input_pptx = _required_workspace_path_alias(
+        project_dir, args, "input_pptx", "pptx_path", "input_path", "path", "input", "file"
+    )
+    output_pptx = _required_workspace_path_alias(
+        project_dir, args, "output_pptx", "output_path", "output", "destination", "dest"
+    )
+    if "edits" not in args and "updates" in args:
+        args["edits"] = args["updates"]
+    if "edits" not in args and "text_boxes" in args:
+        args["edits"] = args["text_boxes"]
+    if "edits" not in args and "targets" in args:
+        targets = _list_arg(args, "targets", required=True)
+        shared = {
+            key: value
+            for key, value in args.items()
+            if key
+            not in {
+                "input_pptx",
+                "pptx_path",
+                "input_path",
+                "path",
+                "input",
+                "file",
+                "output_pptx",
+                "output_path",
+                "output",
+                "destination",
+                "dest",
+                "targets",
+                "text_boxes",
+                "edits",
+                "updates",
+            }
+        }
+        args["edits"] = [
+            {**target, **shared} if isinstance(target, dict) else target for target in targets
+        ]
+    edits = _list_arg(args, "edits", required=True)
+    prs = Presentation(str(input_pptx))
+    applied = 0
+    for edit in edits:
+        if not isinstance(edit, dict):
+            continue
+        nested_style = edit.get("style")
+        if isinstance(nested_style, dict):
+            edit = {**edit, **nested_style}
+        nested_format = edit.get("format")
+        if isinstance(nested_format, dict):
+            edit = {**edit, **nested_format}
+        for slide_idx, slide in enumerate(prs.slides, start=1):
+            if edit.get("slide_index") and int(edit["slide_index"]) != slide_idx:
+                continue
+            for shape in slide.shapes:
+                if not getattr(shape, "has_text_frame", False):
+                    continue
+                if not _pptx_shape_matches(shape, edit):
+                    continue
+                if "new_text" in edit:
+                    shape.text = str(edit["new_text"])
+                elif "text" in edit and not any(
+                    key in edit for key in ("shape_id", "contains", "match_text")
+                ):
+                    shape.text = str(edit["text"])
+                for attr in ("left", "top", "width", "height"):
+                    if attr in edit:
+                        setattr(shape, attr, int(edit[attr]))
+                _apply_pptx_positioning(shape, prs, edit)
+                _apply_pptx_text_frame_options(shape, edit)
+                if "font_size" in edit:
+                    for paragraph in shape.text_frame.paragraphs:
+                        for run in paragraph.runs:
+                            run.font.size = Pt(float(edit["font_size"]))
+                if any(
+                    key in edit for key in ("font_name", "font_color", "bold", "alignment", "align")
+                ):
+                    _apply_pptx_font_style(shape, edit, RGBColor, Pt, PP_ALIGN)
+                applied += 1
+    output_pptx.parent.mkdir(parents=True, exist_ok=True)
+    prs.save(str(output_pptx))
+    return {
+        "input_pptx": str(input_pptx),
+        "output_pptx": str(output_pptx),
+        "requested_edits": len(edits),
+        "applied_edits": applied,
+        "exists": output_pptx.exists(),
+    }
+
+
+def _pptx_add_reference_slide(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from pptx import Presentation
+    from pptx.util import Inches, Pt
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    input_pptx = _required_workspace_path_alias(
+        project_dir, args, "input_pptx", "pptx_path", "input_path", "path", "input", "file"
+    )
+    output_pptx = _required_workspace_path_alias(
+        project_dir, args, "output_pptx", "output_path", "output", "destination", "dest"
+    )
+    if "items" not in args and "references" in args:
+        args["items"] = args["references"]
+    if "items" not in args and "titles" in args:
+        args["items"] = args["titles"]
+    items = [str(item) for item in _list_arg(args, "items", required=True)]
+    if _truthy_arg(args, "deduplicate", default=True):
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for item in items:
+            key = " ".join(item.split()).strip().lower()
+            if key and key not in seen:
+                seen.add(key)
+                deduped.append(item)
+        items = deduped
+    title = str(args.get("title") or "References")
+    numbered = _truthy_arg(args, "numbered", default=True)
+    prs = Presentation(str(input_pptx))
+    blank_layout = prs.slide_layouts[6] if len(prs.slide_layouts) > 6 else prs.slide_layouts[0]
+    slide = prs.slides.add_slide(blank_layout)
+    title_box = slide.shapes.add_textbox(Inches(0.6), Inches(0.35), Inches(9.0), Inches(0.5))
+    title_frame = title_box.text_frame
+    title_frame.text = title
+    title_frame.paragraphs[0].runs[0].font.size = Pt(28)
+    body = slide.shapes.add_textbox(Inches(0.75), Inches(1.05), Inches(8.8), Inches(5.8))
+    frame = body.text_frame
+    frame.clear()
+    for idx, item in enumerate(items, start=1):
+        paragraph = frame.paragraphs[0] if idx == 1 else frame.add_paragraph()
+        paragraph.text = item
+        paragraph.font.size = Pt(14)
+        if numbered:
+            _set_pptx_auto_number(paragraph)
+    output_pptx.parent.mkdir(parents=True, exist_ok=True)
+    prs.save(str(output_pptx))
+    return {
+        "input_pptx": str(input_pptx),
+        "output_pptx": str(output_pptx),
+        "slide_count": len(prs.slides),
+        "items_added": len(items),
+        "exists": output_pptx.exists(),
+    }
+
+
+def _pptx_validate_file(operator: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    from pptx import Presentation
+
+    args = _arguments(inputs, operator)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    path = _required_workspace_path_alias(
+        project_dir, args, "path", "pptx_path", "input_pptx", "file"
+    )
+    is_zip = zipfile.is_zipfile(path)
+    prs = Presentation(str(path))
+    return {
+        "path": str(path),
+        "ok": bool(is_zip),
+        "is_zip": bool(is_zip),
+        "slide_count": len(prs.slides),
+    }
+
+
+def _execute_script(
+    spec: dict[str, Any],
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    sandbox_dir = Path(str(inputs.get("sandbox_dir") or ""))
+    script_path = str(operator.get("script_path") or "")
+    candidate_paths = [
+        sandbox_dir / "skill" / script_path,
+        project_dir / script_path,
+        Path(script_path),
+    ]
+    script = next((path for path in candidate_paths if path.exists()), None)
+    if script is None:
+        return {
+            "status": "blocked",
+            "deopt_reason": "missing_script",
+            "error": f"Script not found: {script_path}",
+        }
+    args = _arguments(inputs, operator)
+    argv = [_python_executable(project_dir), str(script)]
+    bindings = dict(operator.get("input_bindings") or {})
+    input_fields = operator.get("inputs") or []
+    if not input_fields:
+        positional = _script_positional_from_context(args, inputs)
+        if positional:
+            argv.append(positional)
+    for field in input_fields:
+        name = str(field.get("name") or "")
+        if not name or name not in args:
+            if field.get("required"):
+                return {
+                    "status": "blocked",
+                    "deopt_reason": "missing_argument",
+                    "error": f"Missing required argument: {name}",
+                }
+            continue
+        flag = str(bindings.get(name) or "")
+        value = args[name]
+        if isinstance(value, bool):
+            if value and flag:
+                argv.append(flag)
+            elif value and not flag:
+                argv.append(str(value))
+            continue
+        if flag:
+            argv.extend([flag, str(value)])
+        else:
+            argv.append(str(value))
+    return _run(argv, project_dir, _timeout(spec), executor="script_asset")
+
+
+def _script_positional_from_context(args: dict[str, Any], inputs: dict[str, Any]) -> str:
+    for key in (
+        "file",
+        "path",
+        "input",
+        "input_file",
+        "input_path",
+        "source",
+        "source_file",
+        "source_path",
+        "data_file",
+        "csv_file",
+        "json_file",
+        "bibtex_file",
+        "stl_path",
+    ):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    files = inputs.get("files")
+    if isinstance(files, list):
+        for value in files:
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _execute_shell(
+    spec: dict[str, Any],
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    commands = [str(item) for item in operator.get("commands") or [] if item]
+    if not commands:
+        return {
+            "status": "blocked",
+            "deopt_reason": "missing_command",
+            "error": "Operator has no shell command.",
+        }
+    args = _arguments(inputs, operator)
+    command = _bind_command(commands[0], args)
+    project_dir = Path(str(inputs.get("project_dir") or os.getcwd()))
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "invalid_command",
+            "error": str(exc),
+        }
+    return _run(argv, project_dir, _timeout(spec), executor="shell_command")
+
+
+def _run(
+    argv: list[str],
+    cwd: Path,
+    timeout: int,
+    *,
+    executor: str,
+) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=str(cwd),
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "timeout",
+            "error": f"Execution exceeded {timeout}s.",
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+            "executor": executor,
+        }
+    except Exception as exc:
+        return {
+            "status": "blocked",
+            "deopt_reason": "execution_exception",
+            "error": f"{type(exc).__name__}: {exc}",
+            "executor": executor,
+        }
+    if completed.returncode != 0:
+        return {
+            "status": "blocked",
+            "deopt_reason": "nonzero_exit",
+            "error": completed.stderr or completed.stdout or f"exit {completed.returncode}",
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "executor": executor,
+        }
+    return {
+        "status": "completed",
+        "final_output": _parse_output(completed.stdout),
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "executor": executor,
+    }
+
+
+def _guidance_result(spec: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    operator = _select_operator(spec, inputs)
+    if operator is None:
+        return _blocked(
+            spec,
+            "no_match",
+            "No guidance section matched the request.",
+            {"available_operations": _operator_names(spec)},
+        )
+    if _is_lossless_reference_operator(operator):
+        execution = _execute_lossless_reference(spec, operator, inputs)
+        if execution["status"] != "completed":
+            return _blocked(
+                spec,
+                execution.get("deopt_reason") or "reference_lookup_failed",
+                execution.get("error") or "Lossless reference lookup failed.",
+                execution,
+            )
+        return _completed(
+            spec,
+            runtime_status="guidance_only",
+            contribution_type="retrieval_guidance",
+            final_output=execution.get("final_output"),
+            selected_operator=operator,
+            requires_agent_continuation=True,
+            debug_trace={"execution": execution},
+        )
+    return _completed(
+        spec,
+        runtime_status="guidance_only",
+        contribution_type="retrieval_guidance",
+        final_output=_operator_guidance(operator),
+        selected_operator=operator,
+        requires_agent_continuation=True,
+    )
+
+
+def _select_planlet(spec: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any] | None:
+    planlets = [item for item in spec.get("planlets") or [] if isinstance(item, dict)]
+    if not planlets:
+        return None
+    requested = str(inputs.get("planlet") or "").strip().lower()
+    if requested:
+        for planlet in planlets:
+            names = {
+                str(planlet.get("id") or "").lower(),
+                str(planlet.get("intent") or "").lower(),
+            }
+            if requested in names:
+                return planlet
+        for planlet in planlets:
+            if requested in str(planlet.get("id") or "").lower():
+                return planlet
+    request_text = " ".join(
+        str(value)
+        for value in [inputs.get("request"), inputs.get("task"), inputs.get("topic")]
+        if value
+    ).lower()
+    file_text = " ".join(str(value).lower() for value in inputs.get("files") or [])
+    args = _arguments(inputs)
+    arg_text = " ".join(str(value).lower() for value in args.values() if isinstance(value, str))
+    haystack = " ".join([request_text, file_text, arg_text]).strip()
+    if not haystack:
+        return None
+    best: tuple[int, dict[str, Any] | None] = (0, None)
+    for planlet in planlets:
+        score = _planlet_score(planlet, haystack)
+        if score > best[0]:
+            best = (score, planlet)
+    return best[1] if best[0] >= 2 else None
+
+
+def _planlet_score(planlet: dict[str, Any], haystack: str) -> int:
+    score = 0
+    applicability = planlet.get("applicability") if isinstance(planlet.get("applicability"), dict) else {}
+    for ext in applicability.get("file_extensions") or []:
+        if str(ext).lower() and str(ext).lower() in haystack:
+            score += 3
+    for keyword in planlet.get("keywords") or []:
+        word = str(keyword).lower()
+        if len(word) >= 3 and word in haystack:
+            score += 1
+    planlet_id = str(planlet.get("id") or "").lower().replace("_", " ")
+    for word in re.findall(r"[a-z0-9]{3,}", planlet_id):
+        if word in haystack:
+            score += 1
+    return score
+
+
+def _missing_planlet_bindings(planlet: dict[str, Any], inputs: dict[str, Any]) -> list[str]:
+    bindings = planlet.get("bindings") if isinstance(planlet.get("bindings"), dict) else {}
+    required = [str(name) for name in bindings.get("required") or [] if name]
+    args = _arguments(inputs)
+    missing = []
+    for name in required:
+        if not _has_bound_value(_lookup_planlet_binding(name, args, inputs, planlet)):
+            missing.append(name)
+    return missing
+
+
+def _execute_planlet(
+    spec: dict[str, Any],
+    planlet: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    step_results: dict[str, Any] = {}
+    debug_steps: list[dict[str, Any]] = []
+    operators = [op for op in spec.get("operators") or [] if isinstance(op, dict)]
+    args = _arguments(inputs)
+    for step in [item for item in planlet.get("steps") or [] if isinstance(item, dict)]:
+        operation = str(step.get("operation") or "").strip()
+        if not operation:
+            continue
+        operator = _operator_by_name(operators, operation)
+        if operator is None:
+            if bool(step.get("optional")):
+                continue
+            return _blocked(
+                spec,
+                "planlet_operator_missing",
+                f"Planlet step references an unknown operation: {operation}",
+                {"planlet": planlet.get("id"), "step": step.get("id")},
+            )
+        step_args = _bind_planlet_step_arguments(step, args, inputs, planlet)
+        step_inputs = dict(inputs)
+        step_inputs["operation"] = operation
+        step_inputs["arguments"] = step_args
+        step_inputs["execute"] = True
+        validation = _validate_operator_arguments(operator, step_inputs)
+        if validation["errors"]:
+            if bool(step.get("optional")):
+                debug_steps.append(
+                    {
+                        "step": step.get("id") or operation,
+                        "operation": operation,
+                        "status": "skipped",
+                        "validation": validation,
+                    }
+                )
+                continue
+            return _blocked(
+                spec,
+                "invalid_planlet_arguments",
+                f"Invalid arguments for planlet step {step.get('id') or operation}.",
+                {
+                    "planlet": planlet.get("id"),
+                    "step": step.get("id"),
+                    "operator": operation,
+                    **validation,
+                },
+            )
+        execution = _execute_operator(spec, operator, step_inputs)
+        key = str(step.get("id") or operation)
+        step_results[key] = {
+            "operator": operation,
+            "executor": execution.get("executor"),
+            "returncode": execution.get("returncode"),
+            "stdout": execution.get("stdout"),
+            "stderr": execution.get("stderr"),
+            "output": execution.get("final_output"),
+        }
+        debug_steps.append(
+            {
+                "step": key,
+                "operation": operation,
+                "status": execution.get("status"),
+            }
+        )
+        output = execution.get("final_output")
+        if isinstance(output, dict):
+            for output_key in (
+                "output_path",
+                "output_pptx",
+                "output_docx",
+                "output_file",
+                "path",
+            ):
+                if _has_bound_value(output.get(output_key)):
+                    args["last_output_path"] = output[output_key]
+                    break
+        if execution.get("status") != "completed":
+            if bool(step.get("optional")):
+                continue
+            return _blocked(
+                spec,
+                execution.get("deopt_reason") or "planlet_step_failed",
+                execution.get("error") or "Planlet step failed.",
+                {
+                    "planlet": planlet.get("id"),
+                    "step": key,
+                    "operator": operation,
+                    "execution": execution,
+                },
+            )
+    boundary = str(spec.get("boundary") or "adapter")
+    return _completed(
+        spec,
+        runtime_status="planlet_executed",
+        contribution_type="execution" if boundary in _SOLVER_BOUNDARIES else "typed_evidence",
+        final_output={
+            "planlet": _planlet_summary(planlet),
+            "step_results": step_results,
+            "stop_policy": planlet.get("stop_policy") or {},
+        },
+        selected_operator=None,
+        selected_planlet=planlet,
+        requires_agent_continuation=boundary not in _SOLVER_BOUNDARIES,
+        step_results=step_results,
+        debug_trace={"planlet_steps": debug_steps},
+    )
+
+
+def _bind_planlet_step_arguments(
+    step: dict[str, Any],
+    args: dict[str, Any],
+    inputs: dict[str, Any],
+    planlet: dict[str, Any],
+) -> dict[str, Any]:
+    step_spec = step.get("arguments") if isinstance(step.get("arguments"), dict) else {}
+    if step_spec.get("*") == "${arguments}":
+        return dict(args)
+    bound: dict[str, Any] = {}
+    for name, value in step_spec.items():
+        resolved = _resolve_planlet_value(value, args, inputs, planlet)
+        if resolved is _MISSING:
+            continue
+        bound[name] = resolved
+    return bound
+
+
+_MISSING = object()
+
+
+def _resolve_planlet_value(
+    value: Any,
+    args: dict[str, Any],
+    inputs: dict[str, Any],
+    planlet: dict[str, Any],
+) -> Any:
+    if not isinstance(value, str) or not value.startswith("${") or not value.endswith("}"):
+        return value
+    expr = value[2:-1]
+    name, default = _split_planlet_default(expr)
+    if name == "arguments":
+        return dict(args)
+    if name.startswith("arguments."):
+        return args.get(name.removeprefix("arguments."), default)
+    resolved = _lookup_planlet_binding(name, args, inputs, planlet)
+    if _has_bound_value(resolved):
+        return resolved
+    if default is not _MISSING:
+        return default
+    return _MISSING
+
+
+def _split_planlet_default(expr: str) -> tuple[str, Any]:
+    if ":" not in expr:
+        return expr, _MISSING
+    name, raw_default = expr.split(":", 1)
+    raw_default = raw_default.strip()
+    if raw_default == "":
+        return name, ""
+    if raw_default.lower() == "true":
+        return name, True
+    if raw_default.lower() == "false":
+        return name, False
+    if raw_default == "[]":
+        return name, []
+    if raw_default == "{}":
+        return name, {}
+    return name, raw_default
+
+
+def _lookup_planlet_binding(
+    name: str,
+    args: dict[str, Any],
+    inputs: dict[str, Any],
+    planlet: dict[str, Any],
+) -> Any:
+    if _has_bound_value(args.get(name)):
+        return args.get(name)
+    bindings = planlet.get("bindings") if isinstance(planlet.get("bindings"), dict) else {}
+    autobind = bindings.get("autobind") if isinstance(bindings.get("autobind"), dict) else {}
+    for alias in autobind.get(name) or []:
+        value = _lookup_binding_alias(str(alias), args, inputs)
+        if _has_bound_value(value):
+            return value
+    for alias in _argument_aliases(name, ""):
+        value = args.get(alias)
+        if _has_bound_value(value):
+            return value
+    return None
+
+
+def _lookup_binding_alias(alias: str, args: dict[str, Any], inputs: dict[str, Any]) -> Any:
+    if alias == "files[0]":
+        files = inputs.get("files")
+        if isinstance(files, list) and files:
+            return files[0]
+        return None
+    return args.get(alias)
+
+
+def _operator_by_name(operators: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    requested = name.lower()
+    for op in operators:
+        if requested in {
+            str(op.get("id") or "").lower(),
+            str(op.get("name") or "").lower(),
+        }:
+            return op
+    return None
+
+
+def _planlet_guidance(planlet: dict[str, Any], missing: list[str]) -> dict[str, Any]:
+    return {
+        "selected_planlet": _planlet_summary(planlet),
+        "missing_bindings": missing,
+        "required_bindings": list((planlet.get("bindings") or {}).get("required") or []),
+        "optional_bindings": list((planlet.get("bindings") or {}).get("optional") or []),
+        "steps": [
+            {
+                "id": str(step.get("id") or ""),
+                "operation": str(step.get("operation") or ""),
+                "optional": bool(step.get("optional", False)),
+            }
+            for step in planlet.get("steps") or []
+            if isinstance(step, dict)
+        ],
+        "hint": "Provide the missing bindings under `arguments`, or call an exact operation directly.",
+    }
+
+
+def _validate_operator_arguments(
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    args = _arguments(inputs, operator)
+    errors: list[dict[str, Any]] = []
+    for field in operator.get("inputs") or []:
+        if not isinstance(field, dict):
+            continue
+        name = str(field.get("name") or "")
+        if not name:
+            continue
+        value = args.get(name)
+        alias_bound = any(
+            _has_bound_value(args.get(alias))
+            for alias in _argument_aliases(name, str(operator.get("kind") or ""))
+        )
+        if field.get("required", False) and not _has_bound_value(value) and not alias_bound:
+            errors.append(
+                {
+                    "field": name,
+                    "reason": "missing_required",
+                    "accepted_aliases": _argument_aliases(
+                        name, str(operator.get("kind") or "")
+                    ),
+                }
+            )
+            continue
+        if _has_bound_value(value):
+            type_error = _argument_type_error(name, value, str(field.get("type") or ""))
+            if type_error:
+                errors.append(type_error)
+    return {
+        "errors": errors,
+        "bound_arguments": {
+            key: value
+            for key, value in args.items()
+            if isinstance(value, (str, int, float, bool, list, dict)) or value is None
+        },
+        "operation": operator.get("name") or operator.get("id"),
+    }
+
+
+def _select_operator(spec: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any] | None:
+    operators = [op for op in spec.get("operators") or [] if isinstance(op, dict)]
+    if not operators:
+        return None
+    requested = str(inputs.get("operation") or inputs.get("topic") or "").strip().lower()
+    if requested:
+        for op in operators:
+            names = {
+                str(op.get("id") or "").lower(),
+                str(op.get("name") or "").lower(),
+            }
+            if requested in names:
+                return op
+        for op in operators:
+            if requested in str(op.get("name") or "").lower():
+                return op
+    request = " ".join(
+        str(value)
+        for value in [inputs.get("request"), inputs.get("task"), inputs.get("topic")]
+        if value
+    ).lower()
+    if request:
+        best: tuple[int, dict[str, Any] | None] = (0, None)
+        for op in operators:
+            words = set(str(item).lower() for item in op.get("keywords") or [])
+            words.update(re.findall(r"[a-z0-9_]{3,}", str(op.get("name") or "").lower()))
+            score = sum(1 for word in words if word and word in request)
+            if score > best[0]:
+                best = (score, op)
+        if best[1] is not None:
+            return best[1]
+    return operators[0] if len(operators) == 1 else None
+
+
+def _network_blocked(
+    spec: dict[str, Any],
+    operator: dict[str, Any],
+    inputs: dict[str, Any],
+) -> bool:
+    if _is_lossless_reference_operator(operator):
+        return False
+    if _truthy(inputs.get("allow_network")):
+        return False
+    policy = spec.get("execution_policy") or {}
+    if bool(policy.get("allow_network_by_default")):
+        return False
+    flags = set(operator.get("risk_flags") or [])
+    if not flags:
+        flags = set(spec.get("risk_flags") or [])
+    return "network" in flags
+
+
+def _completed(
+    spec: dict[str, Any],
+    *,
+    runtime_status: str,
+    contribution_type: str,
+    final_output: Any,
+    requires_agent_continuation: bool,
+    selected_operator: dict[str, Any] | None = None,
+    selected_planlet: dict[str, Any] | None = None,
+    step_results: dict[str, Any] | None = None,
+    debug_trace: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    boundary = str(spec.get("boundary") or "adapter")
+    return {
+        "status": "completed",
+        "runtime_status": runtime_status,
+        "boundary": boundary,
+        "can_produce_final_answer": boundary in _SOLVER_BOUNDARIES,
+        "requires_agent_continuation": requires_agent_continuation,
+        "contribution_type": contribution_type,
+        "final_output": final_output,
+        "produced_outputs": [],
+        "selected_operator": _operator_summary(selected_operator),
+        "selected_planlet": _planlet_summary(selected_planlet),
+        "step_results": step_results or {},
+        "artifact_boundary": _summary(spec),
+        "debug_trace": debug_trace or {},
+    }
+
+
+def _blocked(
+    spec: dict[str, Any],
+    reason: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    boundary = str(spec.get("boundary") or "adapter")
+    return {
+        "status": "blocked",
+        "runtime_status": "blocked",
+        "boundary": boundary,
+        "can_produce_final_answer": boundary in _SOLVER_BOUNDARIES,
+        "requires_agent_continuation": True,
+        "contribution_type": "none",
+        "final_output": None,
+        "produced_outputs": [],
+        "deopt_reason": reason,
+        "errors": [{"reason": reason, "message": message, "details": details or {}}],
+        "block": {
+            "message": message,
+            "details": details or {},
+            "suggested_actions": [
+                "Continue with normal agent tools or use a more specific operator."
+            ],
+        },
+        "artifact_boundary": _summary(spec),
+    }
+
+
+def _inputs(state: dict[str, Any]) -> dict[str, Any]:
+    global_inputs = dict(state.get("global_inputs") or {})
+    nested = global_inputs.pop("inputs", None)
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        merged.update(global_inputs)
+        return merged
+    return global_inputs
+
+
+def _arguments(inputs: dict[str, Any], operator: dict[str, Any] | None = None) -> dict[str, Any]:
+    args = inputs.get("arguments")
+    merged = dict(args) if isinstance(args, dict) else {}
+    _bind_context_file_if_unambiguous(merged, inputs, operator or {})
+    _coerce_operator_argument_aliases(merged, operator or {})
+    return merged
+
+
+def _bind_context_file_if_unambiguous(
+    args: dict[str, Any],
+    inputs: dict[str, Any],
+    operator: dict[str, Any],
+) -> None:
+    files = inputs.get("files")
+    if not isinstance(files, list) or not files:
+        return
+    first_file = files[0]
+    if not isinstance(first_file, str) or not first_file:
+        return
+    missing_path_args = [
+        name
+        for name in _required_operator_inputs(operator)
+        if not _has_bound_value(args.get(name)) and _is_input_path_like(name)
+    ]
+    if len(missing_path_args) == 1:
+        args[missing_path_args[0]] = first_file
+
+
+def _coerce_operator_argument_aliases(args: dict[str, Any], operator: dict[str, Any]) -> None:
+    if not operator:
+        return
+    kind = str(operator.get("kind") or "")
+    for field in operator.get("inputs") or []:
+        if not isinstance(field, dict):
+            continue
+        name = str(field.get("name") or "")
+        if not name or _has_bound_value(args.get(name)):
+            continue
+        if kind == "pptx_update_text_boxes" and _normalize_argument_name(name) == "edits":
+            continue
+        for alias in _argument_aliases(name, kind):
+            if alias == name:
+                continue
+            value = args.get(alias)
+            if _has_bound_value(value):
+                args[name] = value
+                break
+
+
+def _argument_aliases(name: str, kind: str) -> list[str]:
+    normalized = _normalize_argument_name(name)
+    aliases: dict[str, list[str]] = {
+        "path": ["path", "file", "input", "input_path", "docx_path", "pptx_path", "bibtex"],
+        "file": ["file", "path", "input", "input_path", "bibtex", "bibtex_file"],
+        "input": ["input", "input_path", "path", "file"],
+        "input_file": ["input_file", "file", "path", "input", "input_path"],
+        "input_path": [
+            "input_path",
+            "input",
+            "path",
+            "file",
+            "source",
+            "source_path",
+            "docx_path",
+            "pptx_path",
+            "input_pptx",
+        ],
+        "input_pptx": ["input_pptx", "pptx_path", "input_path", "path", "input", "file"],
+        "output": ["output", "output_path", "output_file", "destination", "dest", "answer"],
+        "output_file": ["output_file", "output", "output_path", "destination", "dest", "answer"],
+        "output_path": [
+            "output_path",
+            "output",
+            "output_file",
+            "destination",
+            "dest",
+            "answer",
+            "answer_file",
+            "output_docx",
+            "output_pptx",
+        ],
+        "output_pptx": [
+            "output_pptx",
+            "output_path",
+            "output",
+            "output_file",
+            "destination",
+            "dest",
+        ],
+        "replacements": ["replacements", "replacement_map", "values", "mapping"],
+        "markers": ["markers", "marker_specs", "blocks"],
+        "items": ["items", "references", "titles"],
+        "edits": ["edits", "updates", "targets", "text_boxes"],
+    }
+    result = list(aliases.get(normalized, [normalized]))
+    if kind == "citation_validate_local" and normalized == "file":
+        result.extend(["bib", "bib_file", "test_bib"])
+    return _dedupe_strings(result)
+
+
+def _dedupe_strings(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _argument_type_error(name: str, value: Any, expected_type: str) -> dict[str, Any] | None:
+    expected = expected_type.strip().lower()
+    if expected in {"", "any"}:
+        return None
+    if expected in {"object", "dict", "mapping"}:
+        if isinstance(value, dict) or _string_parses_as(value, dict):
+            return None
+        return {"field": name, "reason": "type_mismatch", "expected": "object"}
+    if expected in {"array", "list"}:
+        if isinstance(value, list) or _string_parses_as(value, list):
+            return None
+        return {"field": name, "reason": "type_mismatch", "expected": "array"}
+    if expected in {"boolean", "bool"}:
+        if isinstance(value, bool) or str(value).strip().lower() in {
+            "true",
+            "false",
+            "1",
+            "0",
+            "yes",
+            "no",
+            "on",
+            "off",
+        }:
+            return None
+        return {"field": name, "reason": "type_mismatch", "expected": "boolean"}
+    if expected in {"integer", "int"}:
+        try:
+            int(value)
+            return None
+        except Exception:
+            return {"field": name, "reason": "type_mismatch", "expected": "integer"}
+    if expected in {"number", "float"}:
+        try:
+            float(value)
+            return None
+        except Exception:
+            return {"field": name, "reason": "type_mismatch", "expected": "number"}
+    if expected in {"string", "str"} and not isinstance(value, str):
+        return {"field": name, "reason": "type_mismatch", "expected": "string"}
+    return None
+
+
+def _string_parses_as(value: Any, expected_type: type) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        parsed = json.loads(value)
+    except Exception:
+        try:
+            parsed = ast.literal_eval(value)
+        except Exception:
+            return False
+    return isinstance(parsed, expected_type)
+
+
+def _has_bound_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str) and not value.strip():
+        return False
+    return True
+
+
+def _required_operator_inputs(operator: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for field in operator.get("inputs") or []:
+        if not isinstance(field, dict) or not field.get("required", False):
+            continue
+        name = str(field.get("name") or "")
+        if name:
+            names.append(name)
+    return names
+
+
+def _is_input_path_like(name: str) -> bool:
+    normalized = _normalize_argument_name(name)
+    if _is_output_path_like(normalized):
+        return False
+    return (
+        normalized
+        in {
+            "file",
+            "input",
+            "input_file",
+            "input_path",
+            "source",
+            "source_file",
+            "source_path",
+            "path",
+            "config",
+            "config_file",
+            "config_path",
+            "query_file",
+            "data_file",
+            "csv",
+            "csv_file",
+            "json_file",
+            "pdf",
+            "pdf_file",
+            "image",
+            "image_file",
+            "video",
+            "video_file",
+            "audio",
+            "audio_file",
+            "bibtex",
+            "bibtex_file",
+        }
+        or normalized.startswith("input_")
+        or normalized.endswith("_file")
+        or normalized.endswith("_path")
+    )
+
+
+def _is_output_path_like(name: str) -> bool:
+    normalized = _normalize_argument_name(name)
+    return (
+        normalized
+        in {
+            "o",
+            "out",
+            "output",
+            "output_file",
+            "output_path",
+            "output_dir",
+            "output_directory",
+            "output_prefix",
+            "report",
+            "report_file",
+            "answer",
+            "answer_file",
+            "destination",
+            "destination_file",
+            "dest",
+            "dest_file",
+        }
+        or normalized.startswith("output_")
+        or normalized.endswith("_output")
+    )
+
+
+def _normalize_argument_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9_]+", "_", name.strip().lower().replace("-", "_")).strip("_")
+
+
+def _safe_int(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _required_workspace_path(project_dir: Path, args: dict[str, Any], name: str) -> Path:
+    value = args.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Missing required argument: {name}")
+    return _resolve_workspace_path(project_dir, value.strip())
+
+
+def _required_workspace_path_alias(
+    project_dir: Path,
+    args: dict[str, Any],
+    primary: str,
+    *aliases: str,
+) -> Path:
+    for name in (primary, *aliases):
+        value = args.get(name)
+        if isinstance(value, str) and value.strip():
+            return _resolve_workspace_path(project_dir, value.strip())
+    expected = ", ".join((primary, *aliases))
+    raise ValueError(f"Missing required argument: {primary} (accepted aliases: {expected})")
+
+
+def _optional_workspace_path(project_dir: Path, args: dict[str, Any], name: str) -> Path | None:
+    value = args.get(name)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return _resolve_workspace_path(project_dir, value.strip())
+
+
+def _mapping_arg(
+    args: dict[str, Any],
+    name: str,
+    *,
+    required: bool = True,
+) -> dict[str, Any]:
+    value = args.get(name)
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except Exception:
+            value = ast.literal_eval(value)
+    if value is None and not required:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Missing required object argument: {name}")
+    return value
+
+
+def _list_arg(
+    args: dict[str, Any],
+    name: str,
+    *,
+    required: bool = False,
+) -> list[Any]:
+    value = args.get(name)
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except Exception:
+            value = ast.literal_eval(value)
+    if value is None:
+        if required:
+            raise ValueError(f"Missing required list argument: {name}")
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"Argument must be a list: {name}")
+    return value
+
+
+def _truthy_arg(args: dict[str, Any], name: str, *, default: bool) -> bool:
+    if name not in args:
+        return default
+    return _truthy(args.get(name))
+
+
+def _docx_paragraphs(
+    doc: Any,
+    *,
+    include_tables: bool,
+    include_headers_footers: bool,
+) -> list[Any]:
+    paragraphs = list(doc.paragraphs)
+    if include_tables:
+        _extend_docx_table_paragraphs(paragraphs, doc.tables)
+    if include_headers_footers:
+        for section in doc.sections:
+            paragraphs.extend(section.header.paragraphs)
+            paragraphs.extend(section.footer.paragraphs)
+            if include_tables:
+                _extend_docx_table_paragraphs(paragraphs, section.header.tables)
+                _extend_docx_table_paragraphs(paragraphs, section.footer.tables)
+    return paragraphs
+
+
+def _extend_docx_table_paragraphs(paragraphs: list[Any], tables: Any) -> None:
+    for table in tables:
+        for row in table.rows:
+            for cell in row.cells:
+                paragraphs.extend(cell.paragraphs)
+                _extend_docx_table_paragraphs(paragraphs, cell.tables)
+
+
+def _docx_table_text_items(tables: Any, *, prefix: str = "") -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for table_idx, table in enumerate(tables):
+        table_path = f"{prefix}{table_idx}" if not prefix else f"{prefix}.{table_idx}"
+        for row_idx, row in enumerate(table.rows):
+            for cell_idx, cell in enumerate(row.cells):
+                text = "\n".join(p.text for p in cell.paragraphs if p.text)
+                if text:
+                    items.append(
+                        {
+                            "table": table_path,
+                            "row": row_idx,
+                            "cell": cell_idx,
+                            "text": text,
+                        }
+                    )
+                items.extend(_docx_table_text_items(cell.tables, prefix=table_path))
+    return items
+
+
+def _replace_paragraph_text(paragraph: Any, replacements: dict[str, Any]) -> int:
+    original = "".join(run.text for run in paragraph.runs) if paragraph.runs else paragraph.text
+    updated = original
+    for needle, replacement in replacements.items():
+        updated = updated.replace(str(needle), str(replacement))
+    if updated == original:
+        return 0
+    if paragraph.runs:
+        paragraph.runs[0].text = updated
+        for run in paragraph.runs[1:]:
+            run.text = ""
+    else:
+        paragraph.text = updated
+    return 1
+
+
+def _marker_specs(args: dict[str, Any]) -> list[dict[str, Any]]:
+    markers = args.get("markers")
+    if isinstance(markers, str) and markers.strip():
+        try:
+            markers = json.loads(markers)
+        except Exception:
+            markers = ast.literal_eval(markers)
+    if isinstance(markers, dict):
+        markers = [markers]
+    if not markers:
+        start = args.get("start") or args.get("start_marker")
+        end = args.get("end") or args.get("end_marker")
+        if start and end:
+            return [
+                {
+                    "name": args.get("name") or "marker",
+                    "start": start,
+                    "end": end,
+                    "keep": args.get("keep"),
+                }
+            ]
+    if not isinstance(markers, list) or not all(isinstance(item, dict) for item in markers):
+        raise ValueError("Missing required argument: markers")
+    return markers
+
+
+def _apply_pptx_positioning(shape: Any, prs: Any, edit: dict[str, Any]) -> None:
+    position = str(edit.get("position") or "").strip().lower().replace("-", "_")
+    if not position:
+        return
+    from pptx.util import Inches
+
+    if position == "bottom_center":
+        margin = int(edit.get("margin") or Inches(0.25))
+        bottom_margin = int(edit.get("bottom_margin") or Inches(0.18))
+        height = int(edit.get("height") or min(int(shape.height), int(Inches(0.45))))
+        shape.left = margin
+        shape.width = int(prs.slide_width) - (2 * margin)
+        shape.height = height
+        shape.top = int(prs.slide_height) - bottom_margin - height
+        return
+    if position == "center":
+        shape.left = (int(prs.slide_width) - int(shape.width)) // 2
+        shape.top = (int(prs.slide_height) - int(shape.height)) // 2
+        return
+    if position == "bottom":
+        bottom_margin = int(edit.get("bottom_margin") or Inches(0.18))
+        shape.top = int(prs.slide_height) - bottom_margin - int(shape.height)
+
+
+def _apply_pptx_text_frame_options(shape: Any, edit: dict[str, Any]) -> None:
+    if not getattr(shape, "has_text_frame", False):
+        return
+    from pptx.enum.text import MSO_AUTO_SIZE
+
+    text_frame = shape.text_frame
+    if "word_wrap" in edit:
+        text_frame.word_wrap = _bool_value(edit["word_wrap"])
+    if _truthy_arg(edit, "fit_to_one_line", default=False):
+        text_frame.word_wrap = False
+        text_frame.auto_size = MSO_AUTO_SIZE.NONE
+    for attr in ("margin_left", "margin_right", "margin_top", "margin_bottom"):
+        if attr in edit:
+            setattr(text_frame, attr, int(edit[attr]))
+    if _truthy_arg(edit, "zero_margins", default=False) or _truthy_arg(
+        edit, "fit_to_one_line", default=False
+    ):
+        text_frame.margin_left = 0
+        text_frame.margin_right = 0
+        text_frame.margin_top = 0
+        text_frame.margin_bottom = 0
+
+
+def _apply_pptx_font_style(
+    shape: Any, edit: dict[str, Any], rgb_color: Any, pt: Any, pp_align: Any
+) -> None:
+    if not getattr(shape, "has_text_frame", False):
+        return
+    color = _pptx_rgb(edit.get("font_color"), rgb_color) if "font_color" in edit else None
+    alignment = _pptx_alignment(edit.get("alignment", edit.get("align")), pp_align)
+    for paragraph in shape.text_frame.paragraphs:
+        if alignment is not None:
+            paragraph.alignment = alignment
+        if not paragraph.runs and paragraph.text:
+            text = paragraph.text
+            paragraph.clear()
+            paragraph.add_run().text = text
+        for run in paragraph.runs:
+            if "font_name" in edit:
+                run.font.name = str(edit["font_name"])
+            if "font_size" in edit:
+                run.font.size = pt(float(edit["font_size"]))
+            if "bold" in edit:
+                run.font.bold = _bool_value(edit["bold"])
+            if color is not None:
+                run.font.color.rgb = color
+
+
+def _pptx_rgb(value: Any, rgb_color: Any) -> Any:
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        return rgb_color(int(value[0]), int(value[1]), int(value[2]))
+    raw = str(value).strip()
+    if raw.startswith("#"):
+        raw = raw[1:]
+    if len(raw) != 6:
+        raise ValueError(f"Invalid PPTX RGB color: {value!r}")
+    return rgb_color(int(raw[0:2], 16), int(raw[2:4], 16), int(raw[4:6], 16))
+
+
+def _pptx_alignment(value: Any, pp_align: Any) -> Any | None:
+    if value is None:
+        return None
+    mapping = {
+        "center": pp_align.CENTER,
+        "left": pp_align.LEFT,
+        "right": pp_align.RIGHT,
+        "justify": pp_align.JUSTIFY,
+    }
+    return mapping.get(str(value).strip().lower())
+
+
+def _bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _set_pptx_auto_number(paragraph: Any) -> None:
+    from pptx.oxml.ns import qn
+    from pptx.oxml.xmlchemy import OxmlElement
+
+    paragraph.level = 0
+    ppr = paragraph._p.get_or_add_pPr()
+    for child in list(ppr):
+        if child.tag in {qn("a:buNone"), qn("a:buChar"), qn("a:buAutoNum")}:
+            ppr.remove(child)
+    bu_auto_num = OxmlElement("a:buAutoNum")
+    bu_auto_num.set("type", "arabicPeriod")
+    ppr.insert(0, bu_auto_num)
+
+
+def _pptx_shape_matches(shape: Any, edit: dict[str, Any]) -> bool:
+    has_selector = False
+    if "shape_id" in edit:
+        has_selector = True
+        if int(edit["shape_id"]) != int(shape.shape_id):
+            return False
+    if "shape_name" in edit:
+        has_selector = True
+        if str(edit["shape_name"]) != str(shape.name):
+            return False
+    text = shape.text if getattr(shape, "has_text_frame", False) else ""
+    if "match_text" in edit:
+        has_selector = True
+        if str(edit["match_text"]) != text:
+            return False
+    if "contains" in edit:
+        has_selector = True
+        if str(edit["contains"]) not in text:
+            return False
+    return has_selector
+
+
+def _timeout(spec: dict[str, Any]) -> int:
+    raw = (spec.get("execution_policy") or {}).get("timeout_sec", 20)
+    try:
+        return max(1, int(raw))
+    except Exception:
+        return 20
+
+
+def _python_executable(project_dir: Path) -> str:
+    host_python = project_dir / "host_python"
+    if host_python.exists():
+        return str(host_python)
+    return sys.executable
+
+
+def _resolve_workspace_path(project_dir: Path, value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        raw = path.as_posix()
+        mappings = {
+            "/root": project_dir,
+            "/app": project_dir,
+            "/data": project_dir / "data",
+            "/output": project_dir / "output",
+        }
+        for prefix, target in mappings.items():
+            if raw == prefix:
+                return target
+            if raw.startswith(prefix + "/"):
+                return target / raw.removeprefix(prefix + "/")
+        return path
+    return project_dir / path
+
+
+def _bind_command(command: str, args: dict[str, Any]) -> str:
+    bound = command
+    for key, value in args.items():
+        bound = bound.replace(f"<{key}>", shlex.quote(str(value)))
+        bound = bound.replace(f"{{{key}}}", shlex.quote(str(value)))
+    return bound
+
+
+def _parse_output(stdout: str) -> Any:
+    text = stdout.strip()
+    if not text:
+        return ""
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    try:
+        return ast.literal_eval(text)
+    except Exception:
+        return text
+
+
+def _operator_guidance(operator: dict[str, Any]) -> str:
+    parts = [
+        str(operator.get("name") or operator.get("id") or ""),
+        str(operator.get("description") or operator.get("summary") or ""),
+    ]
+    if operator.get("script_path"):
+        parts.append(f"script: {operator['script_path']}")
+    if operator.get("commands"):
+        parts.append("commands:\n" + "\n".join(str(item) for item in operator["commands"]))
+    return "\n\n".join(part for part in parts if part).strip()
+
+
+def _operator_names(spec: dict[str, Any]) -> list[str]:
+    return [
+        str(op.get("name") or op.get("id"))
+        for op in spec.get("operators") or []
+        if isinstance(op, dict)
+    ]
+
+
+def _operator_summary(operator: dict[str, Any] | None) -> dict[str, Any]:
+    if not operator:
+        return {}
+    return {
+        "id": operator.get("id"),
+        "name": operator.get("name"),
+        "kind": operator.get("kind"),
+        "risk_flags": operator.get("risk_flags", []),
+    }
+
+
+def _planlet_summary(planlet: dict[str, Any] | None) -> dict[str, Any]:
+    if not planlet:
+        return {}
+    bindings = planlet.get("bindings") if isinstance(planlet.get("bindings"), dict) else {}
+    return {
+        "id": planlet.get("id"),
+        "intent": planlet.get("intent"),
+        "required_bindings": list(bindings.get("required") or []),
+        "step_count": len(planlet.get("steps") or []),
+    }
+
+
+def _summary(spec: dict[str, Any]) -> dict[str, Any]:
+    boundary = str(spec.get("boundary") or "adapter")
+    selection = spec.get("selection_policy") if isinstance(spec.get("selection_policy"), dict) else {}
+    planlets = [item for item in spec.get("planlets") or [] if isinstance(item, dict)]
+    return {
+        "artifact_id": spec.get("artifact_id", ""),
+        "skill_name": spec.get("skill_name", ""),
+        "boundary": boundary,
+        "direct_call_level": selection.get("direct_call_level", ""),
+        "recommended_planlets": [str(item.get("id") or "") for item in planlets[:3]],
+        "planlet_count": len(planlets),
+        "can_produce_final_answer": boundary in _SOLVER_BOUNDARIES,
+        "requires_agent_continuation": boundary not in _SOLVER_BOUNDARIES,
+        "risk_flags": list(spec.get("risk_flags") or []),
+    }
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)

--- a/aeloon/plugins/SkillGraph/skillgraph/cli.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/cli.py
@@ -4,6 +4,8 @@ import argparse
 import os
 from pathlib import Path
 
+from aeloon.core.config.paths import get_storage_gateway
+
 from . import (
     Analyzer,
     SkillPackage,
@@ -15,6 +17,7 @@ from . import (
 from . import (
     compile as compile_skill,
 )
+from .validator import workflow_blocking_issues
 
 
 def _prepare_cache(package, cache_dir: Path) -> tuple[Path, bool, Path]:
@@ -41,6 +44,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("skill", help="Path to SKILL.md or a skill directory")
     parser.add_argument(
+        "--workspace",
+        default="",
+        help="Aeloon workspace used for default project cache exits (default: current directory)",
+    )
+    parser.add_argument(
         "-o", "--output", default="", help="Output Python file path (required for full compile)"
     )
     parser.add_argument("--model", default="openai/gpt-5.4", help="Analyzer model")
@@ -55,9 +63,23 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.getenv("OPENROUTER_API_KEY", ""),
         help="API key (default: OPENROUTER_API_KEY)",
     )
-    parser.add_argument("--cache-dir", default="output/graphs", help="Graph cache directory")
+    parser.add_argument(
+        "--cache-dir",
+        default="",
+        help="Graph cache directory (default: project cache/skillgraph under --workspace)",
+    )
     parser.add_argument(
         "--report-path", default="", help="Optional explicit path for compile report JSON"
+    )
+    parser.add_argument("--task-context-path", default="", help="Optional task context path")
+    parser.add_argument("--verifier-command", default="", help="Optional verifier command")
+    parser.add_argument("--trace-path", default="", help="Optional successful trace path")
+    parser.add_argument("--target-output", action="append", default=[], help="Expected output path")
+    parser.add_argument("--compile-goal", default="", help="guidance, adapter, workflow, or solver")
+    parser.add_argument(
+        "--artifact-policy",
+        default="",
+        help="Evidence policy for artifact promotion: generic, trace, or family",
     )
     parser.add_argument(
         "--analyze-only",
@@ -70,9 +92,24 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--strict-validate",
         action="store_true",
-        help="Fail compile if SkillGraph validation finds errors (default: loose mode)",
+        help=(
+            "Compatibility flag. Workflow compilation always fails on blocking "
+            "validation issues; validate-only exits nonzero when blockers exist."
+        ),
     )
     return parser
+
+
+def _workspace_root(raw_workspace: str) -> Path:
+    if raw_workspace:
+        return Path(raw_workspace).expanduser()
+    return Path.cwd()
+
+
+def _cache_dir(raw_cache_dir: str, workspace: Path) -> Path:
+    if raw_cache_dir:
+        return Path(raw_cache_dir).expanduser()
+    return get_storage_gateway(workspace).project_cache_root("skillgraph")
 
 
 def main() -> None:
@@ -86,7 +123,8 @@ def main() -> None:
         parser.error("-o/--output is required unless using --analyze-only or --validate-only")
 
     skill_path = Path(args.skill)
-    cache_dir = Path(args.cache_dir)
+    workspace = _workspace_root(args.workspace)
+    cache_dir = _cache_dir(args.cache_dir, workspace)
 
     if args.analyze_only or args.validate_only:
         package = build_skill_package(skill_path)
@@ -109,6 +147,7 @@ def main() -> None:
         if validation.warnings:
             for issue in validation.warnings:
                 print(f"WARN  [{issue.code}] {issue.message} ({issue.step_id or 'graph'})")
+        blocking = workflow_blocking_issues(validation)
 
         report_target = (
             Path(args.report_path)
@@ -119,7 +158,7 @@ def main() -> None:
         report.save(report_target)
         print(report_target)
 
-        if args.strict_validate and validation.errors:
+        if args.strict_validate and blocking:
             raise SystemExit(1)
         return
 
@@ -133,6 +172,12 @@ def main() -> None:
         cache_dir=cache_dir,
         strict_validate=args.strict_validate,
         report_path=Path(args.report_path) if args.report_path else None,
+        task_context_path=Path(args.task_context_path) if args.task_context_path else None,
+        verifier_command=args.verifier_command or None,
+        trace_path=Path(args.trace_path) if args.trace_path else None,
+        target_outputs=list(args.target_output or []),
+        compile_goal=args.compile_goal or None,
+        artifact_policy=args.artifact_policy or None,
     )
     print(output)
 

--- a/aeloon/plugins/SkillGraph/skillgraph/dispatcher_codegen.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/dispatcher_codegen.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -123,6 +123,12 @@ class DispatcherCapability:
     code_example: str
     source_refs: list[dict[str, Any]]
     keywords: list[str]
+    script_path: str = ""
+    input_bindings: dict[str, str] | None = None
+    can_produce_final_answer: bool = False
+    confidence: float = 1.0
+    validation_status: str = "static"
+    provenance: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -135,6 +141,12 @@ class DispatcherCapability:
             "code_example": self.code_example,
             "source_refs": list(self.source_refs),
             "keywords": list(self.keywords),
+            "script_path": self.script_path,
+            "input_bindings": dict(self.input_bindings or {}),
+            "can_produce_final_answer": self.can_produce_final_answer,
+            "confidence": self.confidence,
+            "validation_status": self.validation_status,
+            "provenance": dict(self.provenance or {}),
         }
 
 
@@ -181,6 +193,7 @@ def extract_dispatcher_capabilities(
     package: SkillPackage, entry_skill: Path
 ) -> list[DispatcherCapability]:
     content = entry_skill.read_text(encoding="utf-8") if entry_skill.exists() else ""
+    generic_capabilities = _generic_office_capabilities(package, entry_skill)
     blocks = list(_iter_blocks(content))
     local_modules = {
         Path(asset.path).stem
@@ -260,10 +273,372 @@ def extract_dispatcher_capabilities(
                     code_example=asset.path,
                     source_refs=[{"path": asset.path, "line": None, "snippet": asset.path}],
                     keywords=_build_keywords(asset.path),
+                    script_path=asset.path,
                 )
             )
 
-    return capabilities
+    if generic_capabilities and package.slug in {"docx", "pptx"}:
+        capabilities = [cap for cap in capabilities if cap.kind != "shell_command"]
+    return _dedupe_capabilities(generic_capabilities + capabilities)
+
+
+def _apply_refined_dispatcher_payload(
+    capabilities: list[DispatcherCapability],
+    data: dict[str, Any],
+) -> tuple[list[DispatcherCapability], list[str], bool]:
+    if not isinstance(data, dict):
+        return capabilities, ["refinement_payload_not_object"], False
+    items = data.get("operators")
+    if not isinstance(items, list):
+        return capabilities, ["refinement_missing_operators"], False
+
+    by_source = {
+        str(item.get("source_name") or ""): item for item in items if isinstance(item, dict)
+    }
+    issues: list[str] = []
+    refined: list[DispatcherCapability] = []
+    changed = False
+    for cap in capabilities:
+        item = by_source.get(cap.name)
+        if item is None:
+            refined.append(cap)
+            continue
+        if item.get("include") is False:
+            issues.append(f"dropped_operator:{cap.name}")
+            changed = True
+            continue
+        new_inputs = _refined_inputs(cap, item.get("inputs"), issues)
+        keywords = _list_strings(item.get("keywords"), limit=120) or list(cap.keywords)
+        refined_cap = replace(
+            cap,
+            name=_capability_name(str(item.get("name") or cap.name)),
+            title=_bounded_text(item.get("title"), cap.title, limit=120),
+            summary=_bounded_text(item.get("summary"), cap.summary, limit=700),
+            inputs=new_inputs,
+            keywords=keywords,
+            confidence=_confidence(item.get("confidence"), default=cap.confidence),
+            validation_status="llm_refined_validated",
+            provenance={"refinement": "llm_refined", "source_name": cap.name},
+        )
+        changed = changed or refined_cap.to_dict() != cap.to_dict()
+        refined.append(refined_cap)
+
+    known = {cap.name for cap in capabilities}
+    for source_name in sorted(set(by_source) - known):
+        issues.append(f"ignored_unknown_operator:{source_name}")
+    if not refined:
+        return capabilities, issues + ["refinement_dropped_all_operators"], False
+    return _dedupe_capabilities(refined), issues, changed
+
+
+def _refined_inputs(
+    cap: DispatcherCapability,
+    raw_inputs: Any,
+    issues: list[str],
+) -> list[IOField]:
+    if not isinstance(raw_inputs, list):
+        return [IOField(**field.model_dump()) for field in cap.inputs]
+    existing_by_name = {field.name: field for field in cap.inputs}
+    existing_by_normalized = {_capability_name(field.name): field for field in cap.inputs}
+    if not existing_by_name:
+        if raw_inputs:
+            issues.append(f"ignored_new_inputs_for_schema_free_operator:{cap.name}")
+        return []
+    refined: list[IOField] = []
+    seen: set[str] = set()
+    for item in raw_inputs:
+        if isinstance(item, str):
+            raw_name = item
+            description = ""
+        elif isinstance(item, dict):
+            raw_name = str(item.get("name") or "")
+            description = str(item.get("description") or "")
+        else:
+            continue
+        source = existing_by_name.get(raw_name) or existing_by_normalized.get(
+            _capability_name(raw_name)
+        )
+        if source is None:
+            issues.append(f"ignored_unknown_input:{cap.name}.{raw_name}")
+            continue
+        if source.name in seen:
+            continue
+        field_data = source.model_dump()
+        if description:
+            field_data["description"] = description[:240].rstrip()
+        refined.append(IOField(**field_data))
+        seen.add(source.name)
+    return refined or [IOField(**field.model_dump()) for field in cap.inputs]
+
+
+def _bounded_text(value: Any, fallback: str, *, limit: int) -> str:
+    text = str(value or "").strip()
+    return text[:limit].rstrip() if text else fallback
+
+
+def _list_strings(value: Any, *, limit: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text and text not in out:
+            out.append(text[:80].rstrip())
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _confidence(value: Any, *, default: float) -> float:
+    try:
+        return min(1.0, max(0.0, float(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _field(
+    name: str,
+    *,
+    field_type: str = "string",
+    required: bool = True,
+    description: str = "",
+) -> IOField:
+    return IOField(name=name, type=field_type, required=required, description=description)
+
+
+def _generic_office_capabilities(
+    package: SkillPackage,
+    entry_skill: Path,
+) -> list[DispatcherCapability]:
+    if package.slug == "docx":
+        return _generic_docx_capabilities(entry_skill)
+    if package.slug == "pptx":
+        return _generic_pptx_capabilities(entry_skill)
+    return []
+
+
+def _generic_source_ref(entry_skill: Path, snippet: str) -> list[dict[str, Any]]:
+    return [{"path": entry_skill.name or "SKILL.md", "line": None, "snippet": snippet}]
+
+
+def _generic_docx_capabilities(entry_skill: Path) -> list[DispatcherCapability]:
+    source_refs = _generic_source_ref(
+        entry_skill,
+        "Generic DOCX executable operators derived only from the docx skill package.",
+    )
+    return [
+        DispatcherCapability(
+            name="inspect_docx",
+            title="Inspect DOCX structure",
+            kind="docx_inspect",
+            summary=(
+                "Generic executable operator that summarizes DOCX paragraphs, tables, "
+                "headers, footers, and placeholder-like text."
+            ),
+            inputs=[_field("path", description="Input DOCX workspace path.")],
+            commands=[],
+            code_example="inspect_docx(path)",
+            source_refs=source_refs,
+            keywords=_build_keywords("docx inspect structure paragraphs tables headers footers placeholders"),
+        ),
+        DispatcherCapability(
+            name="replace_docx_text",
+            title="Replace DOCX text",
+            kind="docx_replace_text",
+            summary=(
+                "Generic executable operator for split-run-safe text replacement across "
+                "DOCX body, tables, headers, and footers."
+            ),
+            inputs=[
+                _field("input_path", description="Input DOCX workspace path."),
+                _field("output_path", description="Output DOCX workspace path."),
+                _field(
+                    "replacements",
+                    field_type="object",
+                    description="Mapping of exact text/placeholders to replacement text.",
+                ),
+                _field(
+                    "include_headers_footers",
+                    field_type="boolean",
+                    required=False,
+                    description="Whether to process headers and footers. Defaults to true.",
+                ),
+                _field(
+                    "include_tables",
+                    field_type="boolean",
+                    required=False,
+                    description="Whether to process table cells. Defaults to true.",
+                ),
+            ],
+            commands=[],
+            code_example="replace_docx_text(input_path, output_path, replacements)",
+            source_refs=source_refs,
+            keywords=_build_keywords("docx replace placeholders split runs headers footers tables template"),
+        ),
+        DispatcherCapability(
+            name="remove_or_keep_marked_blocks",
+            title="Remove or keep marked DOCX blocks",
+            kind="docx_marked_blocks",
+            summary=(
+                "Generic executable operator that removes or keeps text blocks delimited "
+                "by caller-provided markers."
+            ),
+            inputs=[
+                _field("input_path", description="Input DOCX workspace path."),
+                _field("output_path", description="Output DOCX workspace path."),
+                _field(
+                    "markers",
+                    field_type="array",
+                    description="Marker specs with name/start/end and optional keep flag.",
+                ),
+                _field(
+                    "conditions",
+                    field_type="object",
+                    required=False,
+                    description="Optional mapping from marker name to keep/remove boolean.",
+                ),
+            ],
+            commands=[],
+            code_example="remove_or_keep_marked_blocks(input_path, output_path, markers)",
+            source_refs=source_refs,
+            keywords=_build_keywords("docx conditional section marker remove keep block template"),
+        ),
+        DispatcherCapability(
+            name="validate_docx_text",
+            title="Validate DOCX text",
+            kind="docx_validate_text",
+            summary="Generic executable operator that checks required and forbidden text in a DOCX.",
+            inputs=[
+                _field("path", description="Input DOCX workspace path."),
+                _field(
+                    "must_contain",
+                    field_type="array",
+                    required=False,
+                    description="Strings that must appear in the DOCX text.",
+                ),
+                _field(
+                    "must_not_contain",
+                    field_type="array",
+                    required=False,
+                    description="Strings that must not appear in the DOCX text.",
+                ),
+            ],
+            commands=[],
+            code_example="validate_docx_text(path, must_contain, must_not_contain)",
+            source_refs=source_refs,
+            keywords=_build_keywords("docx validate text placeholders markers required forbidden"),
+        ),
+    ]
+
+
+def _generic_pptx_capabilities(entry_skill: Path) -> list[DispatcherCapability]:
+    source_refs = _generic_source_ref(
+        entry_skill,
+        "Generic PPTX executable operators derived only from the pptx skill package.",
+    )
+    return [
+        DispatcherCapability(
+            name="inventory_pptx",
+            title="Inventory PPTX",
+            kind="pptx_inventory",
+            summary=(
+                "Generic executable operator that inventories slides, text boxes, shape ids, "
+                "text, and positions from a PPTX."
+            ),
+            inputs=[
+                _field("input_pptx", description="Input PPTX workspace path."),
+                _field("output_json", required=False, description="Optional output JSON report path."),
+                _field(
+                    "include_positions",
+                    field_type="boolean",
+                    required=False,
+                    description="Whether to include shape positions. Defaults to true.",
+                ),
+            ],
+            commands=[],
+            code_example="inventory_pptx(input_pptx, output_json)",
+            source_refs=source_refs,
+            keywords=_build_keywords("pptx inventory slides shapes text boxes positions ids"),
+        ),
+        DispatcherCapability(
+            name="update_pptx_text_boxes",
+            title="Update PPTX text boxes",
+            kind="pptx_update_text_boxes",
+            summary=(
+                "Generic executable operator that updates PPTX text boxes selected by "
+                "slide index, shape id, shape name, exact text, or substring."
+            ),
+            inputs=[
+                _field(
+                    "input_pptx",
+                    description="Input PPTX workspace path. Aliases: input_path, pptx_path, path.",
+                ),
+                _field("output_pptx", description="Output PPTX workspace path. Alias: output_path."),
+                _field(
+                    "edits",
+                    field_type="array",
+                    description=(
+                        "Text-box edit specs with selectors and replacement/style fields. "
+                        "Aliases: updates, text_boxes, or targets plus shared style fields."
+                    ),
+                ),
+            ],
+            commands=[],
+            code_example="update_pptx_text_boxes(input_pptx, output_pptx, edits=[...])",
+            source_refs=source_refs,
+            keywords=_build_keywords("pptx update text boxes shapes font position edit"),
+        ),
+        DispatcherCapability(
+            name="add_pptx_reference_slide",
+            title="Add PPTX reference slide",
+            kind="pptx_add_reference_slide",
+            summary=(
+                "Generic executable operator that appends a slide containing a title and "
+                "numbered or bulleted items supplied at runtime."
+            ),
+            inputs=[
+                _field(
+                    "input_pptx",
+                    description="Input PPTX workspace path. Aliases: input_path, pptx_path, path.",
+                ),
+                _field("output_pptx", description="Output PPTX workspace path. Alias: output_path."),
+                _field("title", required=False, description="Reference slide title."),
+                _field("items", field_type="array", description="Slide list items. Aliases: references, titles."),
+                _field(
+                    "numbered",
+                    field_type="boolean",
+                    required=False,
+                    description="Whether to use real auto-numbering bullets. Defaults to true.",
+                ),
+            ],
+            commands=[],
+            code_example="add_pptx_reference_slide(input_pptx, output_pptx, title='Reference', items=titles)",
+            source_refs=source_refs,
+            keywords=_build_keywords("pptx add reference slide numbered list items"),
+        ),
+        DispatcherCapability(
+            name="validate_pptx_file",
+            title="Validate PPTX file",
+            kind="pptx_validate_file",
+            summary="Generic executable operator that checks PPTX zip and python-pptx loadability.",
+            inputs=[_field("path", description="Input PPTX workspace path.")],
+            commands=[],
+            code_example="validate_pptx_file(path)",
+            source_refs=source_refs,
+            keywords=_build_keywords("pptx validate zip integrity presentation load"),
+        ),
+    ]
+
+
+def _dedupe_capabilities(capabilities: list[DispatcherCapability]) -> list[DispatcherCapability]:
+    counts: dict[str, int] = {}
+    deduped: list[DispatcherCapability] = []
+    for cap in capabilities:
+        counts[cap.name] = counts.get(cap.name, 0) + 1
+        if counts[cap.name] > 1:
+            cap.name = f"{cap.name}_{counts[cap.name]}"
+        deduped.append(cap)
+    return deduped
 
 
 def build_dispatcher_manifest(

--- a/aeloon/plugins/SkillGraph/skillgraph/llm_refinement.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/llm_refinement.py
@@ -1,0 +1,62 @@
+"""LLM refinement metadata helpers for SkillGraph compilation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class LLMRefinementResult:
+    mode: str
+    status: str
+    data: dict[str, Any] = field(default_factory=dict)
+    usage: dict[str, int] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    error: str = ""
+
+
+def record_refinement_metadata(
+    metadata: dict[str, Any] | None,
+    *,
+    kind: str,
+    result: LLMRefinementResult,
+    model: str,
+    applied: bool,
+    issues: list[str],
+) -> None:
+    """Attach refinement status and token usage to the compiler metadata."""
+
+    if metadata is None:
+        return
+    compiler = metadata.setdefault("compiler", {})
+    refinement = compiler.setdefault("refinement", {})
+    refinement[kind] = {
+        "mode": result.mode,
+        "status": result.status,
+        "model": model,
+        "applied": applied,
+        "issues": list(issues),
+    }
+    if result.error:
+        refinement[kind]["error"] = result.error
+
+    token_usage = compiler.setdefault("token_usage", {})
+    aggregate = token_usage.setdefault(
+        "refinement",
+        {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "llm_calls": 0,
+        },
+    )
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens", "llm_calls"):
+        aggregate[key] = int(aggregate.get(key) or 0) + int(result.usage.get(key) or 0)
+    token_usage.setdefault("events", []).extend(result.events)
+
+
+def call_json_refiner(**_: Any) -> LLMRefinementResult:
+    """Placeholder refiner used when the full Pro LLM refinement loop is unavailable."""
+
+    return LLMRefinementResult(mode="disabled", status="skipped")

--- a/aeloon/plugins/SkillGraph/skillgraph/reference_codegen.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/reference_codegen.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +39,10 @@ class ReferenceSection:
     line: int
     formulas: list[str]
     keywords: list[str]
+    query_aliases: list[str] = field(default_factory=list)
+    use_cases: list[str] = field(default_factory=list)
+    confidence: float = 1.0
+    validation_status: str = "static"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -49,7 +53,98 @@ class ReferenceSection:
             "line": self.line,
             "formulas": list(self.formulas),
             "keywords": list(self.keywords),
+            "query_aliases": list(self.query_aliases),
+            "use_cases": list(self.use_cases),
+            "confidence": self.confidence,
+            "validation_status": self.validation_status,
         }
+
+
+def _apply_refined_reference_payload(
+    sections: list[ReferenceSection],
+    data: dict[str, Any],
+) -> tuple[list[ReferenceSection], list[str], bool]:
+    if not isinstance(data, dict):
+        return sections, ["refinement_payload_not_object"], False
+    items = data.get("sections")
+    if not isinstance(items, list):
+        return sections, ["refinement_missing_sections"], False
+
+    refined: list[ReferenceSection] = []
+    issues: list[str] = []
+    changed = False
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        indexes = item.get("source_indexes")
+        if not isinstance(indexes, list):
+            indexes = [item.get("source_index")]
+        source_sections: list[ReferenceSection] = []
+        for raw_index in indexes:
+            try:
+                source_index = int(raw_index)
+            except (TypeError, ValueError):
+                issues.append(f"ignored_invalid_source_index:{raw_index}")
+                continue
+            if source_index < 1 or source_index > len(sections):
+                issues.append(f"ignored_invalid_source_index:{source_index}")
+                continue
+            source_sections.append(sections[source_index - 1])
+        if not source_sections:
+            continue
+
+        first = source_sections[0]
+        formulas: list[str] = []
+        for section in source_sections:
+            for formula in section.formulas:
+                if formula not in formulas:
+                    formulas.append(formula)
+
+        refined.append(
+            ReferenceSection(
+                title=_bounded_text(item.get("title"), first.title, limit=160),
+                heading_path=list(first.heading_path),
+                summary=_bounded_text(item.get("summary"), first.summary, limit=700),
+                body="\n\n".join(section.body for section in source_sections),
+                line=first.line,
+                formulas=formulas,
+                keywords=_list_strings(item.get("keywords"), limit=120) or list(first.keywords),
+                query_aliases=_list_strings(item.get("query_aliases"), limit=80),
+                use_cases=_list_strings(item.get("use_cases"), limit=80),
+                confidence=_confidence(item.get("confidence"), default=first.confidence),
+                validation_status="llm_refined_validated",
+            )
+        )
+        changed = True
+
+    if not refined:
+        return sections, issues + ["refinement_produced_no_sections"], False
+    return refined, issues, changed
+
+
+def _bounded_text(value: Any, fallback: str, *, limit: int) -> str:
+    text = str(value or "").strip()
+    return text[:limit].rstrip() if text else fallback
+
+
+def _list_strings(value: Any, *, limit: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text and text not in result:
+            result.append(text[:120].rstrip())
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _confidence(value: Any, *, default: float) -> float:
+    try:
+        return min(1.0, max(0.0, float(value)))
+    except (TypeError, ValueError):
+        return default
 
 
 def generate_reference_adapter(

--- a/aeloon/plugins/SkillGraph/skillgraph/validator.py
+++ b/aeloon/plugins/SkillGraph/skillgraph/validator.py
@@ -88,6 +88,11 @@ def validate_graph(graph: SkillGraph) -> ValidationResult:
     return result
 
 
+def workflow_blocking_issues(result: ValidationResult) -> list[ValidationIssue]:
+    """Return validation issues that should block executable workflow builds."""
+    return list(result.errors)
+
+
 def _validate_step_execution(step: Step, result: ValidationResult) -> None:
     if step.step_type == StepType.TOOL_CALL:
         if not step.execution_spec or not step.execution_spec.command:

--- a/aeloon/plugins/SkillGraph/tools.py
+++ b/aeloon/plugins/SkillGraph/tools.py
@@ -66,23 +66,68 @@ class WorkflowTool(_BaseWorkflowTool):
         required_text = (
             f" Required inputs: {', '.join(required_inputs)}." if required_inputs else ""
         )
+        boundary = _workflow_boundary(workflow)
+        strategy_hint = _workflow_strategy_hint(boundary)
+        planlet_hint = _workflow_planlet_hint(boundary)
         return (
             f"Run the compiled workflow '{self._workflow_name}' when it exactly matches the task."
             f" {workflow.metadata.description or ''}{required_text} "
+            "Pass boundary fields such as `planlet`, `operation`, `arguments`, and `execute` directly, "
+            "or put them under `inputs`. "
+            f"{strategy_hint} {planlet_hint} "
             "If the workflow becomes blocked, repair the issue with normal tools and then call `resume_workflow`."
         )
 
     @property
     def parameters(self) -> dict[str, Any]:
+        workflow = self._loader.get_workflow(self._workflow_name)
+        if workflow is not None:
+            boundary = _workflow_boundary(workflow)
+            tool_schema = boundary.get("tool_schema") if isinstance(boundary, dict) else None
+            if isinstance(tool_schema, dict) and tool_schema.get("type") == "object":
+                return tool_schema
         return {
             "type": "object",
             "properties": {
                 "inputs": {"type": "object"},
+                "request": {
+                    "type": "string",
+                    "description": "Natural-language request for operator selection.",
+                },
+                "task": {
+                    "type": "string",
+                    "description": "Optional task summary for operator selection.",
+                },
+                "planlet": {
+                    "type": "string",
+                    "description": "Optional reusable skill-level planlet to execute when its bindings are available.",
+                },
+                "operation": {
+                    "type": "string",
+                    "description": "Exact compiled boundary operation to run.",
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "Structured arguments for the selected operation.",
+                },
+                "execute": {
+                    "type": "boolean",
+                    "description": "Set true to execute adapter or operator workflows when inputs are available.",
+                },
+                "allow_network": {
+                    "type": "boolean",
+                    "description": "Explicitly allow network-risk operations.",
+                },
+                "files": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional workspace files relevant to the operation.",
+                },
             },
             "required": [],
         }
 
-    async def execute(self, inputs: dict[str, Any] | None = None, **_: Any) -> str:
+    async def execute(self, inputs: dict[str, Any] | None = None, **kwargs: Any) -> str:
         workflow_name = self._workflow_name
         workflow = self._loader.get_workflow(workflow_name)
         if workflow is None:
@@ -99,6 +144,9 @@ class WorkflowTool(_BaseWorkflowTool):
                 ensure_ascii=False,
             )
 
+        runtime_inputs = dict(inputs) if isinstance(inputs, dict) else {}
+        runtime_inputs.update({key: value for key, value in kwargs.items() if value is not None})
+
         runtime_cfg = self._loader.load_runtime_config(workflow)
         sandbox_dir = str(workflow.sandbox_path) if workflow.sandbox_path else ""
         state = {
@@ -107,7 +155,7 @@ class WorkflowTool(_BaseWorkflowTool):
                 "sandbox_dir": sandbox_dir,
                 "_runtime_config": runtime_cfg,
                 "_llm_callable": make_llm_callable(self._provider, self._model),
-                **(inputs or {}),
+                **runtime_inputs,
             },
             "step_results": {},
             "error": None,
@@ -315,6 +363,84 @@ class WorkflowTool(_BaseWorkflowTool):
             current_step=current_step,
             block=block,
         )
+
+
+def _workflow_boundary(workflow: Any) -> dict[str, Any]:
+    manifest_path = getattr(workflow, "manifest_path", None)
+    if manifest_path is not None and manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8") or "{}")
+        except Exception:
+            manifest = {}
+        metadata = manifest.get("metadata") if isinstance(manifest, dict) else {}
+        boundary = metadata.get("artifact_boundary") if isinstance(metadata, dict) else {}
+        if isinstance(boundary, dict) and boundary:
+            return boundary
+    boundary = getattr(getattr(workflow, "module", None), "ARTIFACT_BOUNDARY", None)
+    return boundary if isinstance(boundary, dict) else {}
+
+
+def _workflow_strategy_hint(boundary: dict[str, Any]) -> str:
+    if not boundary:
+        return ""
+    boundary_kind = str(boundary.get("boundary") or "adapter")
+    selection = boundary.get("selection_policy") if isinstance(boundary, dict) else {}
+    direct_level = str((selection or {}).get("direct_call_level") or "")
+    doc_policy = str((selection or {}).get("doc_read_policy") or "")
+    ops = _boundary_operation_names(boundary)
+    op_text = f" Available operations: {', '.join(ops[:8])}." if ops else ""
+    if boundary_kind == "adapter" and direct_level == "inspect_first":
+        return (
+            "Boundary policy: adapter/inspect_first. Prefer `search_skill_docs` or "
+            "`get_skill_asset` with `arguments`; do not set `execute=true` for workspace "
+            "files unless you intentionally selected an executable operation with all "
+            f"required arguments.{op_text}"
+        )
+    if direct_level in {"operator_first", "solver_first"} or boundary_kind in {
+        "typed_operator",
+        "workflow_solver",
+        "jit_solver",
+    }:
+        return (
+            f"Boundary policy: {boundary_kind}/{direct_level or 'operator_first'}. "
+            "Prefer an exact `operation` plus structured `arguments`; pass workspace "
+            "files through `arguments` and/or `files` instead of relying only on a "
+            f"natural-language request.{op_text}"
+        )
+    if doc_policy == "required":
+        return (
+            f"Boundary policy: {boundary_kind}; read targeted preserved guidance first "
+            f"with `search_skill_docs` or `get_skill_asset` before manual edits.{op_text}"
+        )
+    return f"Boundary policy: {boundary_kind}.{op_text}"
+
+
+def _workflow_planlet_hint(boundary: dict[str, Any]) -> str:
+    planlets = [item for item in boundary.get("planlets") or [] if isinstance(item, dict)]
+    if not planlets:
+        return ""
+    compact = []
+    for planlet in planlets[:4]:
+        bindings = planlet.get("bindings") if isinstance(planlet.get("bindings"), dict) else {}
+        required = ", ".join(str(item) for item in bindings.get("required") or [])
+        required_text = f" requires: {required}" if required else ""
+        compact.append(f"{planlet.get('id')} ({planlet.get('intent')}{required_text})")
+    return (
+        "Reusable planlets available: "
+        + "; ".join(str(item) for item in compact if item)
+        + ". Prefer a matching `planlet` over manually chaining operations when bindings are known."
+    )
+
+
+def _boundary_operation_names(boundary: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for op in boundary.get("operators") or []:
+        if not isinstance(op, dict):
+            continue
+        name = str(op.get("name") or op.get("id") or "")
+        if name and name not in names:
+            names.append(name)
+    return names
 
 
 class ResumeWorkflowTool(_BaseWorkflowTool):

--- a/aeloon/plugins/SkillGraph/workflow_loader.py
+++ b/aeloon/plugins/SkillGraph/workflow_loader.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from loguru import logger
 
+from aeloon.core.config.paths import get_storage_gateway
+
 
 @dataclass
 class WorkflowMetadata:
@@ -32,20 +34,30 @@ class LoadedWorkflow:
 
 
 class WorkflowLoader:
-    """Discover compiled workflows under `<workspace>/compiled_skills`."""
+    """Discover compiled workflows under the project compiled-skill cache."""
 
     def __init__(self, workspace: Path, directory_name: str = "compiled_skills") -> None:
         self.workspace = workspace
-        self.directory = workspace / directory_name
+        if directory_name == "compiled_skills":
+            self.directory = get_storage_gateway(workspace).project_compiled_skills_root(
+                create=False
+            )
+            legacy_directory = workspace / "compiled_skills"
+            self._legacy_directories = (
+                [legacy_directory] if legacy_directory != self.directory else []
+            )
+        else:
+            self.directory = workspace / directory_name
+            self._legacy_directories = []
         self._loaded: dict[str, LoadedWorkflow] = {}
         self.refresh()
 
     def refresh(self) -> None:
         loaded: dict[str, LoadedWorkflow] = {}
-        if self.directory.exists():
-            for path in sorted(self.directory.glob("*_workflow.py")):
+        for directory in self._workflow_directories():
+            for path in sorted(directory.glob("*_workflow.py")):
                 workflow = self._load_one(path)
-                if workflow is not None:
+                if workflow is not None and workflow.metadata.name not in loaded:
                     loaded[workflow.metadata.name] = workflow
         self._loaded = loaded
 
@@ -82,6 +94,13 @@ class WorkflowLoader:
             lines.append("</workflow>")
         lines.append("</compiled-workflows>")
         return "\n".join(lines)
+
+    def _workflow_directories(self) -> list[Path]:
+        return [
+            directory
+            for directory in [self.directory, *self._legacy_directories]
+            if directory.exists()
+        ]
 
     def load_runtime_config(self, workflow: LoadedWorkflow) -> dict[str, Any]:
         if workflow.config_path is None or not workflow.config_path.exists():

--- a/aeloon/plugins/SkillGraph/workflow_state.py
+++ b/aeloon/plugins/SkillGraph/workflow_state.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from aeloon.core.config.paths import get_storage_gateway
+
 
 @dataclass
 class WorkflowExecutionState:
@@ -52,7 +54,7 @@ class WorkflowStateStore:
 
     def __init__(self, workspace: Path) -> None:
         self.workspace = workspace
-        self.root = self.workspace / ".aeloon" / "workflows"
+        self.root = get_storage_gateway(workspace).project_workflows_root()
         self.root.mkdir(parents=True, exist_ok=True)
 
     def create(

--- a/tests/test_skill_compiler.py
+++ b/tests/test_skill_compiler.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import shutil
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
+from aeloon.core.config.paths import get_storage_gateway
 from aeloon.plugins.SkillGraph.compiler import SkillCompilerRequest, compile_skill_to_workspace
 
 
@@ -18,13 +21,9 @@ class _FakeApi:
     compile_skill: object
 
 
-def test_compile_skill_to_workspace_writes_into_compiled_skills(tmp_path, monkeypatch) -> None:
-    skills_dir = tmp_path / "skills" / "demo"
-    skills_dir.mkdir(parents=True)
-    (skills_dir / "SKILL.md").write_text("# Demo", encoding="utf-8")
-
+def _install_fake_skillgraph(monkeypatch: pytest.MonkeyPatch, expected_skill_path: Path) -> None:
     def _fake_build_skill_package(skill_path):
-        assert skill_path == skills_dir.resolve()
+        assert skill_path == expected_skill_path.resolve()
         return _FakePackage(slug="demo")
 
     def _fake_compile_skill(**kwargs):
@@ -61,6 +60,13 @@ def test_compile_skill_to_workspace_writes_into_compiled_skills(tmp_path, monkey
         lambda: _FakeApi(_fake_build_skill_package, _fake_compile_skill),
     )
 
+
+def test_compile_skill_to_workspace_writes_into_compiled_skills(tmp_path, monkeypatch) -> None:
+    skills_dir = tmp_path / "skills" / "demo"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("# Demo", encoding="utf-8")
+    _install_fake_skillgraph(monkeypatch, skills_dir)
+
     provider = type("Provider", (), {"api_key": "key", "api_base": "https://example.com"})()
     result = compile_skill_to_workspace(
         workspace=tmp_path,
@@ -70,11 +76,75 @@ def test_compile_skill_to_workspace_writes_into_compiled_skills(tmp_path, monkey
     )
 
     assert result.workflow_name == "demo"
-    assert result.output_path == tmp_path / "compiled_skills" / "demo_workflow.py"
+    assert result.output_path == (
+        get_storage_gateway(tmp_path).project_compiled_skills_root(create=False)
+        / "demo_workflow.py"
+    )
     assert result.manifest_path.exists()
     assert result.sandbox_path.exists()
     assert result.report_path.exists()
     assert result.config_path.exists()
+
+
+def test_compile_skill_to_workspace_resolves_gateway_skill_root(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    storage = get_storage_gateway(tmp_path)
+    skill_dir = storage.project_skills_root() / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Demo", encoding="utf-8")
+    _install_fake_skillgraph(monkeypatch, skill_dir)
+
+    provider = type("Provider", (), {"api_key": "key", "api_base": "https://example.com"})()
+    result = compile_skill_to_workspace(
+        workspace=tmp_path,
+        provider=provider,
+        default_model="default-model",
+        request=SkillCompilerRequest(skill_path="skills/demo", runtime_model="runtime-model"),
+    )
+
+    assert result.skill_path == skill_dir.resolve()
+    assert result.output_path.parent == storage.project_compiled_skills_root(create=False)
+    assert not (tmp_path / "skills").exists()
+
+
+def test_compiled_skill_cache_can_be_deleted_and_rebuilt_without_source_loss(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    storage = get_storage_gateway(tmp_path)
+    skill_dir = storage.project_skills_root() / "demo"
+    skill_file = skill_dir / "SKILL.md"
+    skill_dir.mkdir(parents=True)
+    skill_file.write_text("# Demo", encoding="utf-8")
+    _install_fake_skillgraph(monkeypatch, skill_dir)
+    provider = type("Provider", (), {"api_key": "key", "api_base": "https://example.com"})()
+    request = SkillCompilerRequest(skill_path="skills/demo", runtime_model="runtime-model")
+
+    first = compile_skill_to_workspace(
+        workspace=tmp_path,
+        provider=provider,
+        default_model="default-model",
+        request=request,
+    )
+    shutil.rmtree(storage.project_compiled_skills_root(create=False))
+    shutil.rmtree(storage.project_cache_root("skillgraph", create=False))
+
+    assert first.output_path.exists() is False
+    assert skill_file.exists()
+
+    second = compile_skill_to_workspace(
+        workspace=tmp_path,
+        provider=provider,
+        default_model="default-model",
+        request=request,
+    )
+
+    assert second.skill_path == skill_dir.resolve()
+    assert second.output_path.exists()
+    assert second.report_path.exists()
+    assert skill_file.exists()
 
 
 def test_compile_skill_to_workspace_raises_when_skillgraph_missing(tmp_path, monkeypatch) -> None:

--- a/tests/test_skill_compiler_command.py
+++ b/tests/test_skill_compiler_command.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from aeloon.core.agent.tools.registry import ToolRegistry
+from aeloon.core.config.paths import get_storage_gateway
 from aeloon.plugins._sdk.api import PluginAPI
 from aeloon.plugins._sdk.registry import PluginRegistry
 from aeloon.plugins._sdk.runtime import PluginRuntime
@@ -117,15 +118,18 @@ async def test_skill_compiler_command_compiles_and_refreshes(tmp_path, monkeypat
     plugin.register(api)
     await plugin.activate(api)
 
+    storage = get_storage_gateway(tmp_path)
+    compiled_dir = storage.project_compiled_skills_root(create=False)
+    skillgraph_cache = storage.project_cache_root("skillgraph", create=False)
     fake_result = SkillCompilerResult(
-        skill_path=tmp_path / "skills" / "demo",
+        skill_path=storage.project_skills_root(create=False) / "demo",
         package_slug="demo",
         workflow_name="demo",
-        output_path=tmp_path / "compiled_skills" / "demo_workflow.py",
-        manifest_path=tmp_path / "compiled_skills" / "demo_workflow.manifest.json",
-        sandbox_path=tmp_path / "compiled_skills" / "demo_workflow.sandbox",
-        report_path=tmp_path / ".aeloon" / "skillgraph" / "demo.report.json",
-        config_path=tmp_path / "compiled_skills" / "skill_config.json",
+        output_path=compiled_dir / "demo_workflow.py",
+        manifest_path=compiled_dir / "demo_workflow.manifest.json",
+        sandbox_path=compiled_dir / "demo_workflow.sandbox",
+        report_path=skillgraph_cache / "demo.report.json",
+        config_path=compiled_dir / "skill_config.json",
         model="test-model",
         runtime_model="override-model",
         base_url="https://example.com",

--- a/tests/test_skillgraph_boundary_runtime.py
+++ b/tests/test_skillgraph_boundary_runtime.py
@@ -1,0 +1,591 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from aeloon.plugins.SkillGraph.skillgraph.boundary import build_boundary_spec
+from aeloon.plugins.SkillGraph.skillgraph.boundary_runtime import run_boundary_artifact
+from aeloon.plugins.SkillGraph.skillgraph.dispatcher_codegen import extract_dispatcher_capabilities
+from aeloon.plugins.SkillGraph.skillgraph.models import RuntimeManifest
+from aeloon.plugins.SkillGraph.skillgraph.package import build_skill_package
+
+
+def _write_lossless_sandbox(tmp_path: Path) -> tuple[Path, dict]:
+    sandbox = tmp_path / "artifact.sandbox"
+    skill_root = sandbox / "skill"
+    skill_root.mkdir(parents=True)
+    (skill_root / "SKILL.md").write_text("# Skill\n\nUse this skill for tests.\n", encoding="utf-8")
+    assets = [
+        {
+            "path": "SKILL.md",
+            "asset_type": "instruction",
+            "is_text": True,
+            "size_bytes": (skill_root / "SKILL.md").stat().st_size,
+            "sha256": "",
+            "line_count": 3,
+        }
+    ]
+    spec = {
+        "boundary": "adapter",
+        "risk_flags": ["network"],
+        "scope": {
+            "lossless_reference": {
+                "strict_validated": False,
+                "package_hash": "pkg",
+                "capsule_hash": "cap",
+                "asset_count": 1,
+                "text_asset_count": 1,
+                "binary_asset_count": 0,
+                "assets": assets,
+            }
+        },
+        "operators": [
+            {"id": "list_skill_assets", "name": "list_skill_assets", "kind": "skill_asset_list"},
+            {"id": "get_skill_asset", "name": "get_skill_asset", "kind": "skill_asset_get"},
+            {"id": "search_skill_docs", "name": "search_skill_docs", "kind": "skill_doc_search"},
+        ],
+        "execution_policy": {"allow_network_by_default": False},
+    }
+    return sandbox, spec
+
+
+def test_lossless_reference_ops_do_not_inherit_artifact_network_risk(tmp_path: Path) -> None:
+    sandbox, spec = _write_lossless_sandbox(tmp_path)
+
+    cases = [
+        ("list_skill_assets", {}),
+        ("get_skill_asset", {"path": "SKILL.md", "max_chars": 20}),
+        ("search_skill_docs", {"query": "skill", "max_results": 1}),
+    ]
+    for operation, arguments in cases:
+        result = run_boundary_artifact(
+            spec,
+            {
+                "global_inputs": {
+                    "sandbox_dir": str(sandbox),
+                    "operation": operation,
+                    "arguments": arguments,
+                },
+                "step_results": {},
+            },
+        )
+        assert result["status"] == "completed", operation
+        assert result["runtime_status"] == "guidance_only"
+
+
+def test_get_skill_asset_requires_explicit_skill_asset_path(tmp_path: Path) -> None:
+    sandbox, spec = _write_lossless_sandbox(tmp_path)
+
+    result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "sandbox_dir": str(sandbox),
+                "operation": "get_skill_asset",
+                "arguments": {},
+                "files": [str(tmp_path / "workspace_template.docx")],
+            },
+            "step_results": {},
+        },
+    )
+
+    assert result["status"] == "blocked"
+    assert "Missing required argument: path" in result["block"]["message"]
+
+
+def test_script_asset_without_schema_uses_context_file_and_parses_python_literal(
+    tmp_path: Path,
+) -> None:
+    sandbox = tmp_path / "artifact.sandbox"
+    script_dir = sandbox / "skill" / "scripts"
+    script_dir.mkdir(parents=True)
+    script = script_dir / "mesh_tool.py"
+    script.write_text(
+        "import sys\nprint({'argc': len(sys.argv), 'arg': sys.argv[1] if len(sys.argv) > 1 else ''})\n",
+        encoding="utf-8",
+    )
+    input_file = tmp_path / "scan_data.stl"
+    input_file.write_text("mesh", encoding="utf-8")
+    spec = {
+        "boundary": "typed_operator",
+        "operators": [
+            {
+                "id": "mesh_tool",
+                "name": "mesh_tool",
+                "kind": "script_asset",
+                "script_path": "scripts/mesh_tool.py",
+                "inputs": [],
+                "risk_flags": [],
+            }
+        ],
+        "execution_policy": {"timeout_sec": 10},
+    }
+
+    result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "sandbox_dir": str(sandbox),
+                "operation": "mesh_tool",
+                "files": [str(input_file)],
+            },
+            "step_results": {},
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert result["final_output"]["argc"] == 2
+    assert result["final_output"]["arg"] == str(input_file)
+
+
+def test_docx_skill_only_capabilities_promote_to_typed_operator(tmp_path: Path) -> None:
+    skill_root = tmp_path / "docx"
+    skill_root.mkdir()
+    entry = skill_root / "SKILL.md"
+    entry.write_text(
+        "# DOCX\n\nUse python-docx for split placeholders.\n\n```bash\npython ad_hoc.py\n```\n",
+        encoding="utf-8",
+    )
+    package = build_skill_package(skill_root)
+
+    capabilities = extract_dispatcher_capabilities(package, entry)
+    names = {cap.name for cap in capabilities}
+    kinds = {cap.kind for cap in capabilities}
+
+    assert "replace_docx_text" in names
+    assert "validate_docx_text" in names
+    assert "shell_command" not in kinds
+
+    spec = build_boundary_spec(
+        strategy="dispatcher",
+        skill_name=package.slug,
+        description="DOCX",
+        runtime_manifest=RuntimeManifest(),
+        package=package,
+        metadata={
+            "task_context": {},
+            "compilability": {
+                "strategy": "dispatcher",
+                "kind": "toolkit_dispatcher",
+                "source_shape": "toolkit",
+                "confidence": "medium",
+            },
+        },
+        dispatcher_capabilities=capabilities,
+    )
+
+    assert spec.boundary == "typed_operator"
+    assert spec.selection_policy["direct_call_level"] == "operator_first"
+    planlet_ids = {planlet.id for planlet in spec.planlets}
+    assert "docx_template_fill_and_validate" in planlet_ids
+    assert spec.scope["kind"] == "skill_package_generic"
+    assert not spec.scope["dynamic_sources_used_for_codegen"]
+
+
+def test_docx_replace_and_validate_generic_operator(tmp_path: Path) -> None:
+    pytest.importorskip("docx")
+    from docx import Document
+
+    source = tmp_path / "template.docx"
+    output = tmp_path / "filled.docx"
+    doc = Document()
+    paragraph = doc.add_paragraph()
+    paragraph.add_run("Hello {{")
+    paragraph.add_run("NAME")
+    paragraph.add_run("}}")
+    table = doc.add_table(rows=1, cols=1)
+    nested = table.cell(0, 0).add_table(rows=1, cols=1)
+    nested.cell(0, 0).text = "Role: {{ROLE}}"
+    doc.save(source)
+    spec = {
+        "boundary": "typed_operator",
+        "operators": [
+            {
+                "id": "replace_docx_text",
+                "name": "replace_docx_text",
+                "kind": "docx_replace_text",
+                "inputs": [
+                    {"name": "input_path", "required": True},
+                    {"name": "output_path", "required": True},
+                    {"name": "replacements", "required": True, "type": "object"},
+                ],
+            },
+            {
+                "id": "validate_docx_text",
+                "name": "validate_docx_text",
+                "kind": "docx_validate_text",
+                "inputs": [{"name": "path", "required": True}],
+            },
+        ],
+        "execution_policy": {"timeout_sec": 10},
+    }
+
+    result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "replace_docx_text",
+                "arguments": {
+                    "input_path": "template.docx",
+                    "output_path": "filled.docx",
+                    "replacements": {"{{NAME}}": "Ada", "{{ROLE}}": "Engineer"},
+                },
+            },
+            "step_results": {},
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert output.exists()
+
+    validation = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "validate_docx_text",
+                "arguments": {
+                    "docx_path": "filled.docx",
+                    "must_contain": ["Ada", "Engineer"],
+                    "must_not_contain": ["{{NAME}}", "{{ROLE}}"],
+                },
+            },
+            "step_results": {},
+        },
+    )
+
+    assert validation["status"] == "completed"
+    assert validation["final_output"]["ok"] is True
+
+
+def test_docx_planlet_executes_fill_and_validate(tmp_path: Path) -> None:
+    pytest.importorskip("docx")
+    from docx import Document
+
+    source = tmp_path / "template.docx"
+    output = tmp_path / "filled.docx"
+    doc = Document()
+    doc.add_paragraph("Hello {{NAME}}")
+    doc.save(source)
+    spec = {
+        "boundary": "typed_operator",
+        "operators": [
+            {
+                "id": "inspect_docx",
+                "name": "inspect_docx",
+                "kind": "docx_inspect",
+                "inputs": [{"name": "path", "required": True, "type": "string"}],
+            },
+            {
+                "id": "replace_docx_text",
+                "name": "replace_docx_text",
+                "kind": "docx_replace_text",
+                "inputs": [
+                    {"name": "input_path", "required": True, "type": "string"},
+                    {"name": "output_path", "required": True, "type": "string"},
+                    {"name": "replacements", "required": True, "type": "object"},
+                ],
+            },
+            {
+                "id": "validate_docx_text",
+                "name": "validate_docx_text",
+                "kind": "docx_validate_text",
+                "inputs": [{"name": "path", "required": True, "type": "string"}],
+            },
+        ],
+        "planlets": [
+            {
+                "id": "docx_template_fill_and_validate",
+                "intent": "Fill and validate a DOCX template.",
+                "steps": [
+                    {
+                        "id": "inspect_template",
+                        "operation": "inspect_docx",
+                        "optional": True,
+                        "arguments": {"path": "${input_path}"},
+                    },
+                    {
+                        "id": "fill_template",
+                        "operation": "replace_docx_text",
+                        "arguments": {
+                            "input_path": "${input_path}",
+                            "output_path": "${output_path}",
+                            "replacements": "${replacements}",
+                        },
+                    },
+                    {
+                        "id": "validate_text",
+                        "operation": "validate_docx_text",
+                        "arguments": {
+                            "path": "${output_path}",
+                            "must_contain": "${must_contain:[]}",
+                            "must_not_contain": "${must_not_contain:[]}",
+                        },
+                    },
+                ],
+                "bindings": {
+                    "required": ["input_path", "output_path", "replacements"],
+                    "optional": ["must_contain", "must_not_contain"],
+                    "autobind": {"input_path": ["files[0]"]},
+                },
+                "keywords": ["docx", "template", "fill"],
+            }
+        ],
+        "execution_policy": {"timeout_sec": 10},
+    }
+
+    result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "planlet": "docx_template_fill_and_validate",
+                "files": ["template.docx"],
+                "arguments": {
+                    "output_path": "filled.docx",
+                    "replacements": {"{{NAME}}": "Ada"},
+                    "must_contain": ["Ada"],
+                    "must_not_contain": ["{{NAME}}"],
+                },
+            },
+            "step_results": {},
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert result["runtime_status"] == "planlet_executed"
+    assert result["selected_planlet"]["id"] == "docx_template_fill_and_validate"
+    assert output.exists()
+    assert result["step_results"]["validate_text"]["output"]["ok"] is True
+
+
+def test_planlet_missing_bindings_returns_guidance(tmp_path: Path) -> None:
+    spec = {
+        "boundary": "typed_operator",
+        "operators": [
+            {
+                "id": "replace_docx_text",
+                "name": "replace_docx_text",
+                "kind": "docx_replace_text",
+                "inputs": [
+                    {"name": "input_path", "required": True, "type": "string"},
+                    {"name": "output_path", "required": True, "type": "string"},
+                    {"name": "replacements", "required": True, "type": "object"},
+                ],
+            }
+        ],
+        "planlets": [
+            {
+                "id": "docx_template_fill_and_validate",
+                "intent": "Fill and validate a DOCX template.",
+                "steps": [{"id": "fill", "operation": "replace_docx_text"}],
+                "bindings": {"required": ["input_path", "output_path", "replacements"]},
+                "keywords": ["docx", "template", "fill"],
+            }
+        ],
+    }
+
+    result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "planlet": "docx_template_fill_and_validate",
+                "arguments": {"input_path": "template.docx"},
+            },
+            "step_results": {},
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert result["runtime_status"] == "planlet_guidance"
+    assert result["final_output"]["missing_bindings"] == ["output_path", "replacements"]
+
+
+def test_operator_argument_aliases_and_type_errors_are_reported(tmp_path: Path) -> None:
+    spec = {
+        "boundary": "typed_operator",
+        "operators": [
+            {
+                "id": "replace_docx_text",
+                "name": "replace_docx_text",
+                "kind": "docx_replace_text",
+                "inputs": [
+                    {"name": "input_path", "required": True, "type": "string"},
+                    {"name": "output_path", "required": True, "type": "string"},
+                    {"name": "replacements", "required": True, "type": "object"},
+                ],
+            }
+        ],
+    }
+
+    result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "replace_docx_text",
+                "arguments": {
+                    "path": "template.docx",
+                    "output": "filled.docx",
+                    "replacements": ["not", "an", "object"],
+                },
+            },
+            "step_results": {},
+        },
+    )
+
+    assert result["status"] == "blocked"
+    details = result["block"]["details"]
+    assert details["bound_arguments"]["input_path"] == "template.docx"
+    assert details["bound_arguments"]["output_path"] == "filled.docx"
+    assert details["errors"] == [
+        {"field": "replacements", "reason": "type_mismatch", "expected": "object"}
+    ]
+
+
+def test_pptx_inventory_update_and_validate_generic_operator(tmp_path: Path) -> None:
+    pytest.importorskip("pptx")
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    source = tmp_path / "deck.pptx"
+    updated = tmp_path / "updated.pptx"
+    inventory = tmp_path / "inventory.json"
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    shape = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+    shape.text = "Original title"
+    shape_id = shape.shape_id
+    prs.save(source)
+    spec = {
+        "boundary": "typed_operator",
+        "operators": [
+            {
+                "id": "inventory_pptx",
+                "name": "inventory_pptx",
+                "kind": "pptx_inventory",
+                "inputs": [{"name": "input_pptx", "required": True}],
+            },
+            {
+                "id": "update_pptx_text_boxes",
+                "name": "update_pptx_text_boxes",
+                "kind": "pptx_update_text_boxes",
+                "inputs": [
+                    {"name": "input_pptx", "required": True},
+                    {"name": "output_pptx", "required": True},
+                    {"name": "edits", "required": True, "type": "array"},
+                ],
+            },
+            {
+                "id": "validate_pptx_file",
+                "name": "validate_pptx_file",
+                "kind": "pptx_validate_file",
+                "inputs": [{"name": "path", "required": True}],
+            },
+            {
+                "id": "add_pptx_reference_slide",
+                "name": "add_pptx_reference_slide",
+                "kind": "pptx_add_reference_slide",
+                "inputs": [
+                    {"name": "input_pptx", "required": True},
+                    {"name": "output_pptx", "required": True},
+                    {"name": "items", "required": True, "type": "array"},
+                ],
+            },
+        ],
+        "execution_policy": {"timeout_sec": 10},
+    }
+
+    inv_result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "inventory_pptx",
+                "arguments": {"pptx_path": "deck.pptx", "output_json": "inventory.json"},
+            },
+            "step_results": {},
+        },
+    )
+    assert inv_result["status"] == "completed"
+    assert inventory.exists()
+    assert inv_result["final_output"]["slides"][0]["shapes"][0]["text"] == "Original title"
+
+    update_result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "update_pptx_text_boxes",
+                "arguments": {
+                    "input_path": "deck.pptx",
+                    "output_path": "updated.pptx",
+                    "targets": [
+                        {"slide_index": 1, "shape_id": shape_id, "new_text": "Updated title"}
+                    ],
+                    "style": {
+                        "font_name": "Arial",
+                        "font_size": 16,
+                        "font_color": "#989596",
+                        "bold": False,
+                        "alignment": "center",
+                        "position": "bottom_center",
+                        "fit_to_one_line": True,
+                    },
+                },
+            },
+            "step_results": {},
+        },
+    )
+    assert update_result["status"] == "completed"
+    assert updated.exists()
+    updated_prs = Presentation(str(updated))
+    updated_shape = updated_prs.slides[0].shapes[0]
+    assert updated_shape.text == "Updated title"
+    assert updated_shape.left < Inches(0.5)
+    assert updated_shape.width > Inches(9)
+
+    validate_result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "validate_pptx_file",
+                "arguments": {"pptx_path": "updated.pptx"},
+            },
+            "step_results": {},
+        },
+    )
+    assert validate_result["status"] == "completed"
+    assert validate_result["final_output"]["ok"] is True
+
+    referenced = tmp_path / "referenced.pptx"
+    add_reference_result = run_boundary_artifact(
+        spec,
+        {
+            "global_inputs": {
+                "project_dir": str(tmp_path),
+                "operation": "add_pptx_reference_slide",
+                "arguments": {
+                    "input_path": "updated.pptx",
+                    "output_path": "referenced.pptx",
+                    "title": "Reference",
+                    "titles": ["Paper A", "Paper A", "Paper B"],
+                },
+            },
+            "step_results": {},
+        },
+    )
+    assert add_reference_result["status"] == "completed"
+    assert add_reference_result["final_output"]["items_added"] == 2
+    assert referenced.exists()
+    ns = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main"}
+    with zipfile.ZipFile(referenced) as zipf:
+        slide_xml = ET.fromstring(zipf.read("ppt/slides/slide2.xml"))
+    assert slide_xml.find(".//a:buAutoNum", ns) is not None

--- a/tests/test_skillgraph_cli.py
+++ b/tests/test_skillgraph_cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from aeloon.core.config.paths import get_storage_gateway
+from aeloon.plugins.SkillGraph.skillgraph import cli
+
+
+@dataclass(frozen=True)
+class _FakePackage:
+    slug: str
+    skill_root: str
+    entry_skill: str = "SKILL.md"
+    package_hash: str = "hash"
+
+    def save(self, path: Path) -> None:
+        path.write_text("{}", encoding="utf-8")
+
+
+@dataclass(frozen=True)
+class _FakeGraph:
+    steps: list[str]
+    edges: list[str]
+
+
+def test_analyze_only_defaults_cache_to_gateway_project_cache(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo", encoding="utf-8")
+    package = _FakePackage(slug="demo", skill_root=str(skill_dir))
+    captured: dict[str, Any] = {}
+
+    class _FakeAnalyzer:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["analyzer_kwargs"] = kwargs
+
+        def analyze(self, entry_skill: Path, *, cache_path: Path, use_cache: bool) -> _FakeGraph:
+            captured["entry_skill"] = entry_skill
+            captured["cache_path"] = cache_path
+            captured["use_cache"] = use_cache
+            cache_path.write_text("{}", encoding="utf-8")
+            return _FakeGraph(steps=["step"], edges=[])
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "build_skill_package", lambda path: package)
+    monkeypatch.setattr(cli, "Analyzer", _FakeAnalyzer)
+    monkeypatch.setattr(cli, "normalize_graph", lambda graph: graph)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skillgraph-compile", str(skill_dir), "--analyze-only", "--api-key", "key"],
+    )
+
+    cli.main()
+
+    expected_cache_dir = get_storage_gateway(tmp_path).project_cache_root(
+        "skillgraph",
+        create=False,
+    )
+    expected_cache_path = expected_cache_dir / "demo.json"
+    assert captured["entry_skill"] == skill_dir / "SKILL.md"
+    assert captured["cache_path"] == expected_cache_path
+    assert captured["use_cache"] is True
+    assert expected_cache_path.exists()
+    assert not (tmp_path / "output" / "graphs").exists()
+    assert str(expected_cache_path) in capsys.readouterr().out
+
+
+def test_cache_dir_override_remains_explicit_developer_output(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    explicit_cache = tmp_path / "custom-cache"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "skillgraph-compile",
+            "demo",
+            "--analyze-only",
+            "--cache-dir",
+            str(explicit_cache),
+        ],
+    )
+
+    args = cli.build_parser().parse_args()
+
+    assert cli._cache_dir(args.cache_dir, tmp_path) == explicit_cache

--- a/tests/test_skillgraph_refinement.py
+++ b/tests/test_skillgraph_refinement.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from aeloon.plugins.SkillGraph.skillgraph.dispatcher_codegen import (
+    DispatcherCapability,
+    _apply_refined_dispatcher_payload,
+)
+from aeloon.plugins.SkillGraph.skillgraph.llm_refinement import (
+    LLMRefinementResult,
+    record_refinement_metadata,
+)
+from aeloon.plugins.SkillGraph.skillgraph.models import IOField
+from aeloon.plugins.SkillGraph.skillgraph.reference_codegen import (
+    ReferenceSection,
+    _apply_refined_reference_payload,
+)
+from aeloon.plugins.SkillGraph.tools import WorkflowTool
+
+
+def test_record_refinement_metadata_aggregates_token_usage() -> None:
+    metadata = {
+        "compiler": {
+            "token_usage": {
+                "analyzer": {
+                    "prompt_tokens": 2,
+                    "completion_tokens": 3,
+                    "total_tokens": 5,
+                    "llm_calls": 1,
+                },
+                "events": [],
+            }
+        }
+    }
+    result = LLMRefinementResult(
+        mode="llm_refined",
+        status="ok",
+        usage={
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+            "llm_calls": 1,
+        },
+        events=[
+            {
+                "label": "dispatcher_llm_refine",
+                "prompt_tokens": 11,
+                "completion_tokens": 7,
+                "total_tokens": 18,
+                "llm_calls": 1,
+            }
+        ],
+    )
+
+    record_refinement_metadata(
+        metadata,
+        kind="dispatcher",
+        result=result,
+        model="model",
+        applied=True,
+        issues=[],
+    )
+
+    compiler = metadata["compiler"]
+    assert compiler["refinement"]["dispatcher"]["applied"] is True
+    assert compiler["token_usage"]["refinement"]["total_tokens"] == 18
+    assert compiler["token_usage"]["events"][0]["label"] == "dispatcher_llm_refine"
+
+
+def test_dispatcher_refinement_rejects_unknown_operator_and_input() -> None:
+    cap = DispatcherCapability(
+        name="mesh_tool",
+        title="Mesh Tool",
+        kind="script_asset",
+        summary="Static summary",
+        inputs=[IOField(name="path", required=True)],
+        commands=[],
+        code_example="scripts/mesh.py",
+        source_refs=[{"path": "scripts/mesh.py", "line": None, "snippet": "mesh"}],
+        keywords=["mesh"],
+        script_path="scripts/mesh.py",
+    )
+
+    refined, issues, applied = _apply_refined_dispatcher_payload(
+        [cap],
+        {
+            "operators": [
+                {
+                    "source_name": "mesh_tool",
+                    "name": "mesh_volume",
+                    "summary": "Compute mesh volume from an existing bundled script.",
+                    "inputs": [
+                        {"name": "path", "description": "Input mesh path."},
+                        {"name": "invented", "description": "Must be ignored."},
+                    ],
+                    "keywords": ["mesh", "volume"],
+                    "confidence": 0.77,
+                },
+                {"source_name": "missing_tool", "name": "bad"},
+            ]
+        },
+    )
+
+    assert applied is True
+    assert refined[0].name == "mesh_volume"
+    assert refined[0].script_path == "scripts/mesh.py"
+    assert [field.name for field in refined[0].inputs] == ["path"]
+    assert refined[0].inputs[0].description == "Input mesh path."
+    assert refined[0].validation_status == "llm_refined_validated"
+    assert "ignored_unknown_operator:missing_tool" in issues
+    assert "ignored_unknown_input:mesh_tool.invented" in issues
+
+
+def test_reference_refinement_preserves_source_body_and_invalid_indexes() -> None:
+    sections = [
+        ReferenceSection(
+            title="Alpha",
+            heading_path=["Alpha"],
+            summary="Alpha summary",
+            body="Alpha body",
+            line=1,
+            formulas=["a+b"],
+            keywords=["alpha"],
+        ),
+        ReferenceSection(
+            title="Beta",
+            heading_path=["Beta"],
+            summary="Beta summary",
+            body="Beta body",
+            line=8,
+            formulas=["c+d"],
+            keywords=["beta"],
+        ),
+    ]
+
+    refined, issues, applied = _apply_refined_reference_payload(
+        sections,
+        {
+            "sections": [
+                {
+                    "source_indexes": [1, 2, 99],
+                    "title": "Combined",
+                    "summary": "Combined guidance",
+                    "keywords": ["combined"],
+                    "query_aliases": ["how to combine"],
+                    "use_cases": ["combined lookup"],
+                    "confidence": 0.9,
+                }
+            ]
+        },
+    )
+
+    assert applied is True
+    assert refined[0].title == "Combined"
+    assert refined[0].body == "Alpha body\n\nBeta body"
+    assert refined[0].formulas == ["a+b", "c+d"]
+    assert refined[0].query_aliases == ["how to combine"]
+    assert refined[0].validation_status == "llm_refined_validated"
+    assert "ignored_invalid_source_index:99" in issues
+
+
+@dataclass
+class _Workflow:
+    manifest_path: Path
+
+
+class _Loader:
+    def __init__(self, workflow: _Workflow) -> None:
+        self.workflow = workflow
+
+    def get_workflow(self, name: str) -> _Workflow:
+        return self.workflow
+
+
+def test_workflow_tool_parameters_uses_boundary_tool_schema(tmp_path: Path) -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "operation": {"type": "string", "enum": ["inspect_docx"]},
+            "arguments": {"type": "object"},
+        },
+        "x-operator-schemas": [{"operation": "inspect_docx"}],
+    }
+    manifest_path = tmp_path / "demo.manifest.json"
+    manifest_path.write_text(
+        json.dumps({"metadata": {"artifact_boundary": {"tool_schema": schema}}}),
+        encoding="utf-8",
+    )
+    tool = WorkflowTool(
+        loader=_Loader(_Workflow(manifest_path=manifest_path)),
+        workflow_name="demo",
+        provider=object(),
+        model="model",
+        workspace=str(tmp_path),
+        state_store=object(),
+    )
+
+    assert tool.parameters == schema


### PR DESCRIPTION
## Summary

Ports the SkillGraph plugin work from `AetherHeart-AI/Aeloon-Pro` source commit `0bb61e3cbfbeaf1cc4451925563aa42f9379eb81` into `AetherHeart-AI/Aeloon`.

## Migrated Scope

- SkillGraph project-local storage paths for compiled workflows, cache, project skills, and workflow state.
- SkillGraph CLI compatibility for workspace/cache defaults and task-aware compile arguments.
- Boundary-first runtime support: artifact boundary metadata, typed operator runtime, planlet execution, lossless reference helpers, DOCX/PPTX generic operators, and LLM refinement metadata helpers.
- Workflow tool boundary schemas/hints and direct boundary argument forwarding.
- Direct SkillGraph regression tests:
  - `tests/test_skillgraph_cli.py`
  - `tests/test_skillgraph_boundary_runtime.py`
  - `tests/test_skillgraph_refinement.py`
  - `tests/test_skill_compiler.py`
  - `tests/test_skill_compiler_command.py`

## Explicitly Excluded

- Pro UI/frontend and UI backend work.
- Pro-only global documentation changes.
- Indirect Pro references such as `aeloon/core/agent/context.py`.
- Pro-only dependencies; `pyproject.toml` is unchanged.

## Test Results

- `uv run pytest ...` could not start because this project environment does not install `pytest` by default (`Failed to spawn: pytest`).
- `uv run ruff ...` likewise could not start because `ruff` is not installed by default.
- Equivalent tool-injected runs passed:
  - `uv run --with pytest --with pytest-asyncio pytest tests/test_skillgraph_cli.py tests/test_skill_compiler.py tests/test_skill_compiler_command.py tests/test_skillgraph_refinement.py tests/test_skillgraph_boundary_runtime.py` -> 19 passed, 3 skipped.
  - `uv run --with ruff ruff check aeloon/plugins/SkillGraph tests/test_skillgraph_cli.py tests/test_skill_compiler.py tests/test_skill_compiler_command.py tests/test_skillgraph_refinement.py tests/test_skillgraph_boundary_runtime.py` -> passed.
  - `git diff --check` -> passed.